### PR TITLE
fix: update notifications auto-hide and Restart button logic

### DIFF
--- a/packages/desktop/src/views/main/App.vue
+++ b/packages/desktop/src/views/main/App.vue
@@ -131,14 +131,31 @@ const updateState = ref<{
   status: string;
   message: string;
   progress?: number;
-  updateAvailable: boolean;
 }>({
   show: false,
   status: "",
   message: "",
   progress: undefined,
-  updateAvailable: false,
 });
+
+// All Electrobun statuses that indicate a download is actively in progress
+const DOWNLOAD_IN_PROGRESS_STATUSES = new Set([
+  "download-starting",
+  "checking-local-tar",
+  "local-tar-found",
+  "local-tar-missing",
+  "fetching-patch",
+  "patch-found",
+  "patch-not-found",
+  "downloading-patch",
+  "applying-patch",
+  "patch-applied",
+  "extracting-version",
+  "patch-chain-complete",
+  "downloading-full-bundle",
+  "download-progress",
+  "decompressing",
+]);
 
 onMounted(() => {
   const onChatMessage = (msg: NormalizedChatMessage) => {
@@ -165,13 +182,37 @@ onMounted(() => {
     updateState.value.status = status.status;
     updateState.value.message = status.message;
     updateState.value.progress = status.progress;
-    if (status.status === "checking" || status.status === "downloading") {
+
+    if (
+      status.status === "checking" ||
+      status.status === "update-available" ||
+      status.status === "download-complete" ||
+      DOWNLOAD_IN_PROGRESS_STATUSES.has(status.status)
+    ) {
+      // Active update flow — keep toast visible
       updateState.value.show = true;
-    }
-    if (status.status === "complete" || status.status === "error") {
+    } else if (status.status === "no-update") {
+      // No update available (includes dev channel) — show briefly then hide
+      updateState.value.show = true;
       setTimeout(() => {
         updateState.value.show = false;
-      }, 3000);
+      }, 2000);
+    } else if (status.status === "error") {
+      updateState.value.show = true;
+      setTimeout(() => {
+        updateState.value.show = false;
+      }, 4000);
+    }
+    // "applying", "extracting", "replacing-app", "launching-new-version", "complete"
+    // are terminal states where the app is about to restart — keep toast visible
+    else if (
+      status.status === "applying" ||
+      status.status === "extracting" ||
+      status.status === "replacing-app" ||
+      status.status === "launching-new-version" ||
+      status.status === "complete"
+    ) {
+      updateState.value.show = true;
     }
   };
 
@@ -214,7 +255,6 @@ async function checkForUpdates() {
   try {
     const result = await rpc.request.checkForUpdate();
     if (result.updateAvailable) {
-      updateState.value.updateAvailable = true;
       await rpc.request.downloadUpdate();
     }
   } catch (err) {
@@ -493,7 +533,7 @@ async function onSendWatched(text: string) {
             <span class="progress-text">{{ updateState.progress }}%</span>
           </div>
         </div>
-        <button v-if="updateState.updateAvailable && !updateState.progress" class="update-btn" @click="applyUpdate">
+        <button v-if="updateState.status === 'download-complete'" class="update-btn" @click="applyUpdate">
           Restart
         </button>
         <button class="update-close" @click="dismissUpdate">


### PR DESCRIPTION
- Handle all real Electrobun status types (no-update, download-progress, download-complete, etc.) — the old code matched 'downloading' which never actually fires
- Dev mode / no-update: show toast briefly then auto-hide after 2s
- Error: auto-hide after 4s
- Restart button now shows only when status === 'download-complete' (download finished, ready to apply), not on the broken updateAvailable && !progress condition that caused premature flashing
- Remove unused updateAvailable field from updateState