### PR TITLE
feat: self-ping message highlight

### DIFF
--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -357,6 +357,9 @@ function onAppearanceChange(s: import('@twirchat/shared/types').AppSettings) {
             :show-badges="settings?.showBadges"
             :font-size="settings?.fontSize"
             :chat-theme="settings?.chatTheme"
+            :accounts="accounts"
+            :self-ping-enabled="settings?.selfPing?.enabled"
+            :self-ping-color="settings?.selfPing?.color"
             @reply="onReply"
           />
         </template>

--- a/packages/desktop/src/views/main/components/ChatMessage.vue
+++ b/packages/desktop/src/views/main/components/ChatMessage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
 import { rpc } from '../main'
-import type { Emote, NormalizedChatMessage } from '@twirchat/shared/types'
+import type { Account, Emote, NormalizedChatMessage } from '@twirchat/shared/types'
 import EmoteTooltip from './EmoteTooltip.vue'
 
 const props = defineProps<{
@@ -13,6 +13,9 @@ const props = defineProps<{
   showBadges?: boolean
   fontSize?: number
   chatTheme?: 'modern' | 'compact'
+  accounts?: Account[]
+  selfPingEnabled?: boolean
+  selfPingColor?: string
 }>()
 
 const emit = defineEmits<{
@@ -24,6 +27,20 @@ function onReply() {
 }
 
 const isSystemMessage = computed(() => props.message.type === 'system')
+
+const isSelfPing = computed((): boolean => {
+  if (!props.selfPingEnabled || !props.accounts?.length) return false
+  const myAccount = props.accounts.find((a) => a.platform === props.message.platform)
+  if (!myAccount) return false
+  const lower = props.message.text.toLowerCase()
+  const username = myAccount.username.toLowerCase()
+  const displayName = myAccount.displayName.toLowerCase()
+  return lower.includes(`@${username}`) || lower.includes(`@${displayName}`)
+})
+
+const selfPingStyle = computed(() =>
+  isSelfPing.value && props.selfPingColor ? { background: props.selfPingColor } : {},
+)
 
 const systemAction = computed<'added' | 'removed' | 'renamed'>(() => {
   const t = props.message.text
@@ -287,8 +304,8 @@ onMounted(() => {
   <div
     v-else-if="props.chatTheme === 'compact'"
     class="msg msg-compact"
-    :class="`platform-${message.platform}`"
-    :style="{ '--font-size': `${props.fontSize ?? 14}px` }"
+    :class="[`platform-${message.platform}`, { 'self-ping': isSelfPing }]"
+    :style="{ '--font-size': `${props.fontSize ?? 14}px`, ...selfPingStyle }"
     @click="onMsgClick"
     @mouseenter="showCopyButton = true"
     @mouseleave="showCopyButton = false"
@@ -432,8 +449,12 @@ onMounted(() => {
   <div
     v-else
     class="msg"
-    :class="[`platform-${message.platform}`, message.type === 'action' ? 'is-action' : '']"
-    :style="{ '--font-size': `${props.fontSize ?? 14}px` }"
+    :class="[
+      `platform-${message.platform}`,
+      message.type === 'action' ? 'is-action' : '',
+      { 'self-ping': isSelfPing },
+    ]"
+    :style="{ '--font-size': `${props.fontSize ?? 14}px`, ...selfPingStyle }"
     @click="onMsgClick"
     @mouseenter="showCopyButton = true"
     @mouseleave="showCopyButton = false"
@@ -614,6 +635,10 @@ onMounted(() => {
 
 .msg:hover {
   background: rgba(255, 255, 255, 0.025);
+}
+
+.msg.self-ping:hover {
+  filter: brightness(1.08);
 }
 
 /* Platform stripe on left edge */

--- a/packages/desktop/src/views/main/components/SettingsPanel.vue
+++ b/packages/desktop/src/views/main/components/SettingsPanel.vue
@@ -13,11 +13,15 @@ const emit = defineEmits<{
   change: [settings: AppSettings]
 }>()
 
-const local = ref<AppSettings>(
-  props.settings
-    ? { ...props.settings, overlay: { ...props.settings.overlay } }
-    : { ...DEFAULT_SETTINGS, overlay: { ...DEFAULT_SETTINGS.overlay } },
-)
+function makeLocal(s: AppSettings): AppSettings {
+  return {
+    ...s,
+    overlay: { ...s.overlay },
+    selfPing: { ...(s.selfPing ?? DEFAULT_SETTINGS.selfPing!) },
+  }
+}
+
+const local = ref<AppSettings>(makeLocal(props.settings ?? DEFAULT_SETTINGS))
 
 // Flag to avoid feedback loop: when local changes → App updates settings prop → we'd reset local again
 let ignorePropSync = false
@@ -29,7 +33,7 @@ watch(
       return
     }
     if (s) {
-      local.value = { ...s, overlay: { ...s.overlay } }
+      local.value = makeLocal(s)
     }
   },
 )
@@ -39,7 +43,7 @@ watch(
   local,
   (s) => {
     ignorePropSync = true
-    emit('change', { ...s, overlay: { ...s.overlay } })
+    emit('change', makeLocal(s))
     // Reset flag on next tick after Vue has propagated the prop update
     Promise.resolve().then(() => {
       ignorePropSync = false
@@ -55,7 +59,7 @@ async function save() {
   saving.value = true
   try {
     await rpc.request.saveSettings!(local.value)
-    emit('saved', { ...local.value, overlay: { ...local.value.overlay } })
+    emit('saved', makeLocal(local.value))
     saved.value = true
     setTimeout(() => {
       saved.value = false
@@ -166,7 +170,53 @@ function copyOverlayUrl() {
         </div>
       </section>
 
-      <!-- 7TV Emotes -->
+      <!-- Self-Ping Highlight -->
+      <section class="settings-section">
+        <h3 class="section-title">Self-Ping Highlight</h3>
+        <p class="section-desc">Highlight messages that mention your own nickname</p>
+
+        <div class="form-row">
+          <div class="form-label">
+            <span>Enable highlights</span>
+            <span class="form-hint">Highlight messages mentioning you</span>
+          </div>
+          <label class="switch">
+            <input v-model="local.selfPing!.enabled" type="checkbox" />
+            <span class="switch-thumb" />
+          </label>
+        </div>
+
+        <div class="form-row">
+          <div class="form-label">
+            <span>Highlight color</span>
+          </div>
+          <div class="color-row">
+            <input
+              v-model="local.selfPing!.color"
+              class="input-sm"
+              placeholder="rgba(167, 139, 250, 0.15)"
+            />
+            <input v-model="local.selfPing!.color" type="color" class="color-swatch" />
+          </div>
+        </div>
+
+        <div class="form-row form-row-preview">
+          <div class="form-label">
+            <span>Preview</span>
+            <span class="form-hint">How a pinged message looks</span>
+          </div>
+          <div
+            class="ping-preview"
+            :style="local.selfPing!.enabled ? { background: local.selfPing!.color } : {}"
+          >
+            <span class="ping-preview-author">StreamerName:</span>
+            <span class="ping-preview-text">
+              Hey <span class="ping-preview-mention">@YourName</span> what do you think?
+            </span>
+          </div>
+        </div>
+      </section>
+
       <!-- Updates -->
       <section class="settings-section">
         <h3 class="section-title">Updates</h3>
@@ -633,5 +683,37 @@ function copyOverlayUrl() {
 }
 .btn-copy:hover {
   background: rgba(167, 139, 250, 0.22);
+}
+
+.form-row-preview {
+  align-items: flex-start;
+  padding-top: 12px;
+}
+
+.ping-preview {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  border: 1px solid var(--c-border, #2a2a33);
+  min-width: 200px;
+  transition: background 0.2s;
+}
+
+.ping-preview-author {
+  font-weight: 700;
+  color: #a78bfa;
+  flex-shrink: 0;
+}
+
+.ping-preview-text {
+  color: var(--c-text, #e2e2e8);
+}
+
+.ping-preview-mention {
+  color: #a78bfa;
+  font-weight: 600;
 }
 </style>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -108,6 +108,13 @@ export interface ChatLayout {
   splits: SplitConfig[]
 }
 
+export interface SelfPingConfig {
+  /** Highlight messages that mention the user's own platform nickname */
+  enabled: boolean
+  /** Background color applied to self-ping messages (CSS color string) */
+  color: string
+}
+
 export interface AppSettings {
   theme: 'light' | 'dark'
   chatTheme: 'modern' | 'compact'
@@ -124,6 +131,8 @@ export interface AppSettings {
   autoCheckUpdates?: boolean
   /** Chat layout configuration (combined / split) */
   chatLayout?: ChatLayout
+  /** Self-ping highlight settings */
+  selfPing?: SelfPingConfig
 }
 
 export interface OverlayConfig {
@@ -171,6 +180,10 @@ export const DEFAULT_SETTINGS: AppSettings = {
     version: 1,
     mode: 'combined',
     splits: [{ id: 'default', type: 'combined', size: 100 }],
+  },
+  selfPing: {
+    enabled: true,
+    color: 'rgba(167, 139, 250, 0.15)',
   },
 }
 


### PR DESCRIPTION
## Summary

Closes #26

- Add `SelfPingConfig` type + `selfPing` field to `AppSettings` (enabled by default, purple tint color)
- Detect `@username` / `@displayName` mentions per-platform against the authenticated account
- Apply configurable background highlight to matched messages in both modern and compact chat themes
- New **Self-Ping Highlight** section in Settings: toggle, color picker, and live preview

## Changes

| File | Change |
|------|--------|
| `packages/shared/types.ts` | `SelfPingConfig` interface, `selfPing` in `AppSettings` + `DEFAULT_SETTINGS` |
| `packages/desktop/src/views/main/components/SettingsPanel.vue` | Settings UI: toggle + color picker + live preview |
| `packages/desktop/src/views/main/components/ChatList.vue` | Pass `accounts`, `selfPingEnabled`, `selfPingColor` to `ChatMessage` |
| `packages/desktop/src/views/main/components/ChatMessage.vue` | `isSelfPing` computed, `selfPingStyle`, applied to modern + compact themes |

## Behavior

- Enabled by default — highlight activates immediately after auth
- Checks if `message.text` contains `@username` or `@displayName` (case-insensitive) for the platform the message came from
- Color is fully configurable via color picker; defaults to `rgba(167, 139, 250, 0.15)`