### PR TITLE
fix: show chat appearance settings on all channel tabs

### DIFF
--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -334,12 +334,8 @@ function onAppearanceChange(s: import('@twirchat/shared/types').AppSettings) {
         >{{ activeMessages.length }} messages</span
       >
 
-      <!-- Appearance popup button — only in home tab -->
-      <ChatAppearancePopover
-        v-if="settings && !watchedChannel"
-        :settings="settings"
-        @change="onAppearanceChange"
-      />
+      <!-- Appearance popup button -->
+      <ChatAppearancePopover v-if="settings" :settings="settings" @change="onAppearanceChange" />
     </div>
 
     <!-- Messages + scroll pill wrapper -->


### PR DESCRIPTION
## Summary

Closes #27

- Removes the `!watchedChannel` guard from `ChatAppearancePopover`'s `v-if` in `ChatList.vue`, so the appearance settings gear button is no longer hidden when viewing a watched channel tab
- The full `settings-change` event chain (ChatList → PanelNode → SplitNode → WatchedChannelsView → App) already existed and persists settings correctly — no other changes needed