### PR TITLE
feat(desktop): Windows custom titlebar

### DIFF
--- a/packages/desktop/src/bun/index.ts
+++ b/packages/desktop/src/bun/index.ts
@@ -210,6 +210,8 @@ startAuthServer()
 
 const currentStatuses = new Map<string, PlatformStatusInfo>()
 
+let win!: InstanceType<typeof BrowserWindow>
+
 // ============================================================
 // 2. Define Electrobun RPC (bun side)
 // ============================================================
@@ -493,6 +495,26 @@ const rpc = defineElectrobunRPC<TwirChatRPCSchema>('bun', {
         void openBrowser(url)
       },
 
+      getPlatform: () => process.platform as 'win32' | 'darwin' | 'linux',
+
+      windowMinimize: () => {
+        win.minimize()
+      },
+
+      windowMaximize: () => {
+        if (win.isMaximized()) {
+          win.unmaximize()
+        } else {
+          win.maximize()
+        }
+      },
+
+      windowClose: () => {
+        win.close()
+      },
+
+      windowIsMaximized: () => win.isMaximized(),
+
       // ---- Watched Channels Layout ----
 
       getTabChannelIds: () => {
@@ -751,15 +773,27 @@ async function resolveWindowUrl(): Promise<string> {
 
 const windowUrl = await resolveWindowUrl()
 
-const win = new BrowserWindow({
+win = new BrowserWindow({
   frame: { height: 800, width: 1200, x: 0, y: 0 },
   rpc,
   title: 'TwirChat',
   url: windowUrl,
+  ...(process.platform === 'win32' ? { titleBarStyle: 'hidden' as const } : {}),
 })
 
 if (channel === 'dev') {
   win.webview.openDevTools()
+}
+
+if (process.platform === 'win32') {
+  let lastMaximized = win.isMaximized()
+  win.on('resize', () => {
+    const nowMaximized = win.isMaximized()
+    if (nowMaximized !== lastMaximized) {
+      lastMaximized = nowMaximized
+      sendToView.window_maximized_change(nowMaximized)
+    }
+  })
 }
 
 // ============================================================

--- a/packages/desktop/src/shared/rpc.ts
+++ b/packages/desktop/src/shared/rpc.ts
@@ -139,6 +139,18 @@ type BunRequests = {
   /** Open external URL in system browser */
   openExternalUrl: { params: { url: string }; response: void }
 
+  // ---- Window controls (custom titlebar, Windows only) ----
+  /** Get current OS platform identifier */
+  getPlatform: { params: void; response: 'win32' | 'darwin' | 'linux' }
+  /** Minimize the main window */
+  windowMinimize: { params: void; response: void }
+  /** Toggle maximize / restore on the main window */
+  windowMaximize: { params: void; response: void }
+  /** Close the main window */
+  windowClose: { params: void; response: void }
+  /** Returns true when the main window is currently maximized */
+  windowIsMaximized: { params: void; response: boolean }
+
   // ---- Watched Channels Layout (per-tab) ----
   /** Get the list of watched channel IDs that have standalone tabs */
   getTabChannelIds: { params: void; response: string[] | null }
@@ -192,6 +204,8 @@ type WebviewMessages = {
   watched_channel_message: { channelId: string; message: NormalizedChatMessage }
   /** Status changed for a watched channel */
   watched_channel_status: { channelId: string; status: PlatformStatusInfo }
+  /** Window maximize state changed (Windows custom titlebar) */
+  window_maximized_change: boolean
 }
 
 // ----------------------------------------------------------------

--- a/packages/desktop/src/views/main/App.vue
+++ b/packages/desktop/src/views/main/App.vue
@@ -7,6 +7,7 @@ import EventsFeed from './components/EventsFeed.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import ChannelTabBar from './components/ChannelTabBar.vue'
 import AddChannelModal from './components/AddChannelModal.vue'
+import TitleBar from './components/TitleBar.vue'
 import { rpc } from './main'
 import { attemptMigration } from './services/migration'
 import type {
@@ -487,204 +488,207 @@ async function onSendWatched({ text, channelId }: { text: string; channelId?: st
       settings?.fontFamily ? `font-${settings.fontFamily}` : 'font-inter',
     ]"
   >
-    <!-- Left icon navigation -->
-    <nav class="nav-rail" :class="{ collapsed: sidebarCollapsed }">
-      <div class="nav-logo">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-          <rect x="2" y="3" width="20" height="14" rx="3" fill="currentColor" opacity=".9" />
-          <path
-            d="M7 21h10M12 17v4"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-          />
-        </svg>
-      </div>
-
-      <div class="nav-items">
-        <button
-          class="nav-item"
-          :class="{ active: activeTab === 'chat' }"
-          title="Chat"
-          @click="switchTab('chat')"
-        >
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-          </svg>
-          <span class="nav-label">Chat</span>
-        </button>
-
-        <button
-          class="nav-item"
-          :class="{ active: activeTab === 'events' }"
-          title="Events"
-          @click="switchTab('events')"
-        >
-          <div class="nav-item-inner">
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
-              <path d="M13.73 21a2 2 0 0 1-3.46 0" />
-            </svg>
-            <span v-if="unreadEvents > 0" class="badge">{{
-              unreadEvents > 99 ? '99+' : unreadEvents
-            }}</span>
-          </div>
-          <span class="nav-label">Events</span>
-        </button>
-
-        <button
-          class="nav-item"
-          :class="{ active: activeTab === 'platforms' }"
-          title="Platforms"
-          @click="switchTab('platforms')"
-        >
-          <div class="nav-item-inner">
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <circle cx="12" cy="12" r="10" />
-              <line x1="2" y1="12" x2="22" y2="12" />
-              <path
-                d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
-              />
-            </svg>
-            <span v-if="connectedAccountsCount > 0" class="badge badge-green">
-              {{ connectedAccountsCount }}
-            </span>
-          </div>
-          <span class="nav-label">Platforms</span>
-        </button>
-
-        <button
-          class="nav-item"
-          :class="{ active: activeTab === 'settings' }"
-          title="Settings"
-          @click="switchTab('settings')"
-        >
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <circle cx="12" cy="12" r="3" />
+    <TitleBar />
+    <div class="app-body">
+      <!-- Left icon navigation -->
+      <nav class="nav-rail" :class="{ collapsed: sidebarCollapsed }">
+        <div class="nav-logo">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <rect x="2" y="3" width="20" height="14" rx="3" fill="currentColor" opacity=".9" />
             <path
-              d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+              d="M7 21h10M12 17v4"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
             />
           </svg>
-          <span class="nav-label">Settings</span>
-        </button>
-      </div>
+        </div>
 
-      <!-- Collapse toggle button -->
-      <button
-        class="nav-collapse-btn"
-        :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
-        @click="toggleSidebar"
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          :class="{ 'icon-flipped': sidebarCollapsed }"
+        <div class="nav-items">
+          <button
+            class="nav-item"
+            :class="{ active: activeTab === 'chat' }"
+            title="Chat"
+            @click="switchTab('chat')"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+            </svg>
+            <span class="nav-label">Chat</span>
+          </button>
+
+          <button
+            class="nav-item"
+            :class="{ active: activeTab === 'events' }"
+            title="Events"
+            @click="switchTab('events')"
+          >
+            <div class="nav-item-inner">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+                <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+              </svg>
+              <span v-if="unreadEvents > 0" class="badge">{{
+                unreadEvents > 99 ? '99+' : unreadEvents
+              }}</span>
+            </div>
+            <span class="nav-label">Events</span>
+          </button>
+
+          <button
+            class="nav-item"
+            :class="{ active: activeTab === 'platforms' }"
+            title="Platforms"
+            @click="switchTab('platforms')"
+          >
+            <div class="nav-item-inner">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="2" y1="12" x2="22" y2="12" />
+                <path
+                  d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+                />
+              </svg>
+              <span v-if="connectedAccountsCount > 0" class="badge badge-green">
+                {{ connectedAccountsCount }}
+              </span>
+            </div>
+            <span class="nav-label">Platforms</span>
+          </button>
+
+          <button
+            class="nav-item"
+            :class="{ active: activeTab === 'settings' }"
+            title="Settings"
+            @click="switchTab('settings')"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <circle cx="12" cy="12" r="3" />
+              <path
+                d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+              />
+            </svg>
+            <span class="nav-label">Settings</span>
+          </button>
+        </div>
+
+        <!-- Collapse toggle button -->
+        <button
+          class="nav-collapse-btn"
+          :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+          @click="toggleSidebar"
         >
-          <polyline points="15 18 9 12 15 6" />
-        </svg>
-      </button>
-    </nav>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            :class="{ 'icon-flipped': sidebarCollapsed }"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+      </nav>
 
-    <!-- Main content area -->
-    <main class="content">
-      <!-- Channel tab bar for watched channels -->
-      <ChannelTabBar
-        v-if="activeTab === 'chat'"
-        :watched-channels="tabWatchedChannels"
-        :active-tab-id="activeWatchedTab"
-        :watched-statuses="watchedStatuses"
-        :watched-live-statuses="watchedLiveStatuses"
-        :tab-channel-names="tabChannelNames"
-        @select-tab="activeWatchedTab = $event"
-        @add-channel="showAddModal = true"
-        @remove-channel="onRemoveChannel"
-      />
+      <!-- Main content area -->
+      <main class="content">
+        <!-- Channel tab bar for watched channels -->
+        <ChannelTabBar
+          v-if="activeTab === 'chat'"
+          :watched-channels="tabWatchedChannels"
+          :active-tab-id="activeWatchedTab"
+          :watched-statuses="watchedStatuses"
+          :watched-live-statuses="watchedLiveStatuses"
+          :tab-channel-names="tabChannelNames"
+          @select-tab="activeWatchedTab = $event"
+          @add-channel="showAddModal = true"
+          @remove-channel="onRemoveChannel"
+        />
 
-      <!-- Home tab: combined chat across all own channels -->
-      <ChatList
-        v-if="activeTab === 'chat' && activeWatchedTab === 'home' && settings"
-        :messages="messages"
-        :settings="settings"
-        :accounts="accounts"
-        :statuses="statuses"
-        @settings-change="onSettingsChange"
-      />
+        <!-- Home tab: combined chat across all own channels -->
+        <ChatList
+          v-if="activeTab === 'chat' && activeWatchedTab === 'home' && settings"
+          :messages="messages"
+          :settings="settings"
+          :accounts="accounts"
+          :statuses="statuses"
+          @settings-change="onSettingsChange"
+        />
 
-      <!-- Watched channel tab: per-tab independent layout -->
-      <WatchedChannelsView
-        v-if="activeTab === 'chat' && activeWatchedTab !== 'home' && settings"
-        :tab-id="activeWatchedTab"
-        :messages="messages"
-        :settings="settings"
-        :accounts="accounts"
-        :statuses="statuses"
-        :watched-messages="watchedMessages"
-        :watched-statuses="watchedStatuses"
-        :watched-channels="watchedChannels"
-        :on-add-watched-channel="doAddWatchedChannel"
-        @tab-channels-updated="onTabChannelsUpdated"
-        @settings-change="onSettingsChange"
-        @send-watched="onSendWatched"
-      />
+        <!-- Watched channel tab: per-tab independent layout -->
+        <WatchedChannelsView
+          v-if="activeTab === 'chat' && activeWatchedTab !== 'home' && settings"
+          :tab-id="activeWatchedTab"
+          :messages="messages"
+          :settings="settings"
+          :accounts="accounts"
+          :statuses="statuses"
+          :watched-messages="watchedMessages"
+          :watched-statuses="watchedStatuses"
+          :watched-channels="watchedChannels"
+          :on-add-watched-channel="doAddWatchedChannel"
+          @tab-channels-updated="onTabChannelsUpdated"
+          @settings-change="onSettingsChange"
+          @send-watched="onSendWatched"
+        />
 
-      <EventsFeed v-show="activeTab === 'events'" :events="events" />
+        <EventsFeed v-show="activeTab === 'events'" :events="events" />
 
-      <PlatformsPanel
-        v-show="activeTab === 'platforms'"
-        :accounts="accounts"
-        :statuses="statuses"
-        @accounts-updated="accounts = $event"
-      />
+        <PlatformsPanel
+          v-show="activeTab === 'platforms'"
+          :accounts="accounts"
+          :statuses="statuses"
+          @accounts-updated="accounts = $event"
+        />
 
-      <SettingsPanel
-        v-show="activeTab === 'settings'"
-        :settings="settings"
-        @saved="onSettingsSaved"
-        @change="onSettingsChange"
-      />
-    </main>
+        <SettingsPanel
+          v-show="activeTab === 'settings'"
+          :settings="settings"
+          @saved="onSettingsSaved"
+          @change="onSettingsChange"
+        />
+      </main>
+    </div>
 
     <!-- Add channel modal -->
     <AddChannelModal
@@ -788,10 +792,18 @@ body {
 <style scoped>
 .app {
   display: flex;
+  flex-direction: column;
   height: 100vh;
   overflow: hidden;
   background: #0f0f11;
   color: #e2e2e8;
+}
+
+.app-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
 }
 
 /* Light theme overrides */

--- a/packages/desktop/src/views/main/components/TitleBar.vue
+++ b/packages/desktop/src/views/main/components/TitleBar.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { rpc } from '../main'
+
+const platform = ref<string>('')
+const isMaximized = ref<boolean>(false)
+
+const onMaximizeChange = (val: boolean) => {
+  isMaximized.value = val
+}
+
+onMounted(async () => {
+  platform.value = await rpc.request.getPlatform()
+  isMaximized.value = await rpc.request.windowIsMaximized()
+  rpc.addMessageListener('window_maximized_change', onMaximizeChange)
+})
+
+onUnmounted(() => {
+  rpc.removeMessageListener('window_maximized_change', onMaximizeChange)
+})
+
+function minimize() {
+  void rpc.request.windowMinimize()
+}
+
+function toggleMaximize() {
+  void rpc.request.windowMaximize()
+}
+
+function close() {
+  void rpc.request.windowClose()
+}
+</script>
+
+<template>
+  <div v-if="platform === 'win32'" class="titlebar electrobun-webkit-app-region-drag">
+    <div class="titlebar-brand">
+      <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" style="color: #a78bfa">
+        <rect x="2" y="3" width="20" height="14" rx="3" fill="currentColor" opacity=".9" />
+        <path d="M7 21h10M12 17v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      </svg>
+      <span class="titlebar-title">TwirChat</span>
+    </div>
+    <div class="titlebar-controls electrobun-webkit-app-region-no-drag">
+      <button class="titlebar-btn btn-minimize" @click="minimize" title="Minimize">
+        <svg viewBox="0 0 16 16" width="10" height="10">
+          <line
+            x1="3"
+            y1="8"
+            x2="13"
+            y2="8"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+      <button
+        class="titlebar-btn btn-maximize"
+        @click="toggleMaximize"
+        :title="isMaximized ? 'Restore' : 'Maximize'"
+      >
+        <svg v-if="!isMaximized" viewBox="0 0 16 16" width="10" height="10">
+          <rect
+            x="3"
+            y="3"
+            width="10"
+            height="10"
+            rx="1"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          />
+        </svg>
+        <svg v-else viewBox="0 0 16 16" width="10" height="10">
+          <rect
+            x="5"
+            y="3"
+            width="8"
+            height="8"
+            rx="1"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          />
+          <rect
+            x="3"
+            y="5"
+            width="8"
+            height="8"
+            rx="1"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          />
+        </svg>
+      </button>
+      <button class="titlebar-btn btn-close" @click="close" title="Close">
+        <svg viewBox="0 0 16 16" width="10" height="10">
+          <line
+            x1="4"
+            y1="4"
+            x2="12"
+            y2="12"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+          <line
+            x1="12"
+            y1="4"
+            x2="4"
+            y2="12"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 32px;
+  flex-shrink: 0;
+  background: #111114;
+  padding: 0 0 0 12px;
+  user-select: none;
+}
+
+.titlebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.titlebar-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #e2e2e8;
+  font-family: var(--font-family, 'Inter', sans-serif);
+  margin-left: 6px;
+}
+
+.titlebar-controls {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  margin-left: auto;
+}
+
+.titlebar-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  cursor: default;
+  transition: background 0.1s ease;
+  flex-shrink: 0;
+}
+
+.titlebar-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 1);
+}
+
+.btn-close:hover {
+  background: #e81123;
+  color: #fff;
+}
+</style>


### PR DESCRIPTION
## Summary

- Hides the native Windows titlebar (`titleBarStyle: 'hidden'`) and replaces it with a branded Vue component — only on `win32`, macOS/Linux are untouched
- `TitleBar.vue` renders a 32px bar with the TwirChat logo, drag region, and min/maximize/close buttons in Discord-inspired Windows style (close button turns red on hover, maximize icon toggles between states)
- Window control RPC methods (`getPlatform`, `windowMinimize`, `windowMaximize`, `windowClose`, `windowIsMaximized`) + `window_maximized_change` push message added to the schema

## Notes

- Known trade-off (accepted): `titleBarStyle: 'hidden'` loses native Win11 rounded corners and snap-to-edge (Electrobun issue #320)
- `let win!` declared before `defineElectrobunRPC` so handlers can reference the window instance; assigned immediately after `BrowserWindow` construction