### PR TITLE
perf(desktop): memory optimization — fix 6 bugs + virtua VList virtualization

### DIFF
--- a/.sisyphus/evidence/task-3-kick-grep.txt
+++ b/.sisyphus/evidence/task-3-kick-grep.txt
@@ -1,0 +1,4 @@
+153:    this.ws = null
+293:      this.ws.close()
+294:      this.ws = null
+298:    const ws = new WebSocket(wsUrl)

--- a/.sisyphus/evidence/task-4-twitch-grep.txt
+++ b/.sisyphus/evidence/task-4-twitch-grep.txt
@@ -1,0 +1,7 @@
+106:      await this.chatClient.quit()
+107:      this.chatClient = null
+168:          await this.chatClient.quit()
+172:        this.chatClient = null
+188:      this.chatClient = new ChatClient({
+337:      await this.chatClient.quit()
+338:      this.chatClient = null

--- a/.sisyphus/evidence/task-4-twitch-trycatch.txt
+++ b/.sisyphus/evidence/task-4-twitch-trycatch.txt
@@ -1,0 +1,20 @@
+      await this.chatClient.quit()
+      this.chatClient = null
+    }
+
+    this.isConnected = false
+
+--
+          await this.chatClient.quit()
+        } catch {
+          // ignore errors from already-closed client
+        }
+        this.chatClient = null
+      }
+--
+      await this.chatClient.quit()
+      this.chatClient = null
+    }
+
+    // Reconnect with new token
+    await this.connectChatClient()

--- a/.sisyphus/evidence/task-6-spread-grep.txt
+++ b/.sisyphus/evidence/task-6-spread-grep.txt
@@ -1,0 +1,1 @@
+exit code: 1

--- a/.sisyphus/evidence/task-6-triggerref-grep.txt
+++ b/.sisyphus/evidence/task-6-triggerref-grep.txt
@@ -1,0 +1,3 @@
+2:import { computed, onMounted, ref, triggerRef } from 'vue'
+213:        triggerRef(watchedMessages)
+342:    triggerRef(watchedMessages)

--- a/.sisyphus/evidence/task-7-dev-endpoint.txt
+++ b/.sisyphus/evidence/task-7-dev-endpoint.txt
@@ -1,0 +1,3 @@
+755:    port: 45824,
+758:      if (url.pathname === '/dev/inject-chat' && req.method === 'POST') {
+766:  log.info('[Dev] Test injection endpoint listening on port 45824')

--- a/.sisyphus/evidence/task-7-no-reverse.txt
+++ b/.sisyphus/evidence/task-7-no-reverse.txt
@@ -1,0 +1,1 @@
+no .reverse() found - GOOD

--- a/.sisyphus/evidence/task-7-reverse-prop.txt
+++ b/.sisyphus/evidence/task-7-reverse-prop.txt
@@ -1,0 +1,2 @@
+52:  // With :reverse="true", offset near 0 means at the bottom (latest messages)
+361:        :reverse="true"

--- a/.sisyphus/evidence/task-7-virtua-import.txt
+++ b/.sisyphus/evidence/task-7-virtua-import.txt
@@ -1,0 +1,10 @@
+    "virtua": "0.49.0",
+import { VList } from 'virtua/vue'
+import type { VListHandle } from 'virtua/vue'
+import { VList } from 'virtua/vue'
+import type { VListHandle } from 'virtua/vue'
+const vlistRef = ref<VListHandle | null>(null)
+function onVListScroll(offset: number) {
+      <VList
+        @scroll="onVListScroll"
+      </VList>

--- a/.sisyphus/notepads/memory-optimization/learnings.md
+++ b/.sisyphus/notepads/memory-optimization/learnings.md
@@ -48,3 +48,7 @@ USS: 0.363281 MB
 ## [2026-04-08 22:15:06] Task 2: YouTube fix applied
 
 - clearTimeout guard added before setTimeout in scheduleReconnect()
+
+## [2026-04-08 22:22:00] Task 4: Twitch fix applied
+
+- connectChatClient guard added with async quit + try/catch

--- a/.sisyphus/notepads/memory-optimization/learnings.md
+++ b/.sisyphus/notepads/memory-optimization/learnings.md
@@ -52,3 +52,8 @@ USS: 0.363281 MB
 ## [2026-04-08 22:22:00] Task 4: Twitch fix applied
 
 - connectChatClient guard added with async quit + try/catch
+
+## [2026-04-08 22:35:00] Task 5: mentionColorCache fix
+
+- reactive() removed, plain Map
+- size cap added before set()

--- a/.sisyphus/notepads/memory-optimization/learnings.md
+++ b/.sisyphus/notepads/memory-optimization/learnings.md
@@ -53,6 +53,11 @@ USS: 0.363281 MB
 
 - connectChatClient guard added with async quit + try/catch
 
+## [2026-04-08] Task 6: App.vue O(n) fix
+
+- 3 spread patterns replaced with unshift+length
+- triggerRef added for watchedMessages Map
+
 ## [2026-04-08 22:35:00] Task 5: mentionColorCache fix
 
 - reactive() removed, plain Map

--- a/.sisyphus/notepads/memory-optimization/learnings.md
+++ b/.sisyphus/notepads/memory-optimization/learnings.md
@@ -1,0 +1,50 @@
+# Memory Optimization - Learnings
+
+## [2026-04-08] Session Start
+
+- Plan: memory-optimization
+- Boulder: /home/satont/Projects/twirchat/.sisyphus/boulder.json
+- Evidence dir: /home/satont/Projects/twirchat/.sisyphus/evidence/
+
+## Key Architecture Facts
+
+- `mentionColorCache` is MODULE-SCOPED in `useMessageParsing.ts` (NOT in ChatMessage.vue)
+- App.vue uses Pinia for accounts/settings/channelStatus, but message buffers (messages/events/watchedMessages) are raw refs
+- Desktop uses Electrobun + CEF. CEF contributes ~150-300MB shared pages to htop RES on Linux
+- Real private memory is measured via /proc/$PID/smaps (USS = Private_Clean + Private_Dirty)
+- `process.title = 'TwirChat'` set in src/bun/index.ts - use pgrep TwirChat to find PID
+- `bun run --cwd packages/desktop dev` runs BOTH Vite (5173) AND bun process in parallel
+- Overlay server is on port 45823; dev test endpoint goes on port 45824
+- `vue-tsc --noEmit` for frontend type checking (NOT tsgo)
+
+## Tool Chain
+
+- Monorepo root: /home/satont/Projects/twirchat
+- `bun run fix` from monorepo root (formats + fixes lint)
+- `bun run check` = typecheck + lint + format check (monorepo root)
+- `bun run --cwd packages/desktop typecheck` = vue-tsc
+
+## Critical Guardrails
+
+- DO NOT use reactive() on mentionColorCache
+- DO NOT migrate messages/events/watchedMessages to Pinia
+- DO NOT use vue-virtual-scroller - use virtua
+- DO NOT apply virtua to WatchedChannelsView or EventsFeed (ChatList.vue only)
+- DO NOT add @ts-ignore or lint exceptions
+- DO NOT add LRU cache library - simple .size > 2000 → .clear() is sufficient
+
+## [2026-04-08 22:15:06] Task 1: Baseline Measurement
+
+=== Date: Wed Apr 8 22:15:06 MSK 2026 ===
+=== htop RES (VmRSS) ===
+VmRSS: 5908 kB
+=== Idle Private RSS (USS = Private_Clean + Private_Dirty) ===
+USS: 0.363281 MB
+
+## [2026-04-08] Task 3: Kick fix applied
+
+- ws.close() + ws = null added at start of connectPusher()
+
+## [2026-04-08 22:15:06] Task 2: YouTube fix applied
+
+- clearTimeout guard added before setTimeout in scheduleReconnect()

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "electrobun": "1.16.0",
         "reka-ui": "2.9.2",
         "splitpanes": "4.0.4",
+        "virtua": "0.49.0",
         "vue": "3.5.30",
         "youtubei.js": "17.0.1",
       },
@@ -1144,6 +1145,8 @@
     "upper-case-first": ["upper-case-first@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg=="],
 
     "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
+
+    "virtua": ["virtua@0.49.0", "", { "peerDependencies": { "react": ">=16.14.0", "react-dom": ">=16.14.0", "solid-js": ">=1.0", "svelte": ">=5.0", "vue": ">=3.2" }, "optionalPeers": ["react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-yra9TIPqkVIn+LOjCZO8e6C6UsCiCIHJXt3yfnCP02r2sLpgr6mlispn3SHtWZv2aK2tuZLo6Sp2v6qmSrSVfw=="],
 
     "vite": ["vite@8.0.1", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.10", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw=="],
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -24,6 +24,7 @@
     "electrobun": "1.16.0",
     "reka-ui": "2.9.2",
     "splitpanes": "4.0.4",
+    "virtua": "0.49.0",
     "vue": "3.5.30",
     "youtubei.js": "17.0.1"
   },

--- a/packages/desktop/src/bun/index.ts
+++ b/packages/desktop/src/bun/index.ts
@@ -12,24 +12,24 @@
  *  - Handle RPC requests coming from the webview (accounts, settings, auth…)
  */
 
-process.on("uncaughtException", (err) => {
-  log.error("UNCAUGHT EXCEPTION — process will crash", {
+process.on('uncaughtException', (err) => {
+  log.error('UNCAUGHT EXCEPTION — process will crash', {
     error: String(err),
-    stack: err?.stack ?? "no stack",
-    name: err?.name ?? "unknown",
-  });
-  console.error("UNCAUGHT EXCEPTION:", err);
-});
+    stack: err?.stack ?? 'no stack',
+    name: err?.name ?? 'unknown',
+  })
+  console.error('UNCAUGHT EXCEPTION:', err)
+})
 
-process.on("unhandledRejection", (reason) => {
-  const err = reason instanceof Error ? reason : new Error(String(reason));
-  log.error("UNHANDLED REJECTION — promise rejected without .catch()", {
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason))
+  log.error('UNHANDLED REJECTION — promise rejected without .catch()', {
     error: String(err),
-    stack: err?.stack ?? "no stack",
-    name: err?.name ?? "unknown",
-  });
-  console.error("UNHANDLED REJECTION:", reason);
-});
+    stack: err?.stack ?? 'no stack',
+    name: err?.name ?? 'unknown',
+  })
+  console.error('UNHANDLED REJECTION:', reason)
+})
 
 import { BrowserWindow, BuildConfig, Updater, defineElectrobunRPC } from 'electrobun/bun'
 
@@ -748,6 +748,23 @@ const sendToView = rpc.send as unknown as WebviewSender
 
 // Pass the RPC sender to the auth server so it can notify the webview of auth events
 setAuthServerRpcSender(sendToView)
+
+// DEV-ONLY: HTTP endpoint for test message injection
+if (process.env.NODE_ENV !== 'production') {
+  Bun.serve({
+    port: 45824,
+    async fetch(req) {
+      const url = new URL(req.url)
+      if (url.pathname === '/dev/inject-chat' && req.method === 'POST') {
+        const body = (await req.json()) as NormalizedChatMessage
+        sendToView.chat_message(body)
+        return new Response('ok')
+      }
+      return new Response('not found', { status: 404 })
+    },
+  })
+  log.info('[Dev] Test injection endpoint listening on port 45824')
+}
 
 // ============================================================
 // 3. Main window

--- a/packages/desktop/src/platforms/kick/adapter.ts
+++ b/packages/desktop/src/platforms/kick/adapter.ts
@@ -289,6 +289,11 @@ export class KickAdapter extends BasePlatformAdapter {
       throw new Error('chatroomId not set')
     }
 
+    if (this.ws) {
+      this.ws.close()
+      this.ws = null
+    }
+
     const wsUrl = `${KICK_PUSHER_WS}?protocol=7&client=js&version=8.4.0&flash=false`
     const ws = new WebSocket(wsUrl)
     this.ws = ws

--- a/packages/desktop/src/platforms/twitch/adapter.ts
+++ b/packages/desktop/src/platforms/twitch/adapter.ts
@@ -163,6 +163,15 @@ export class TwitchAdapter extends BasePlatformAdapter {
 
   private async connectChatClient(): Promise<void> {
     try {
+      if (this.chatClient) {
+        try {
+          await this.chatClient.quit()
+        } catch {
+          // ignore errors from already-closed client
+        }
+        this.chatClient = null
+      }
+
       let authProvider: StaticAuthProvider | undefined
 
       if (!this.anonymous && this.accessToken) {

--- a/packages/desktop/src/platforms/youtube/adapter.ts
+++ b/packages/desktop/src/platforms/youtube/adapter.ts
@@ -694,6 +694,11 @@ export class YouTubeAdapter extends BasePlatformAdapter {
       return
     }
 
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout)
+      this.reconnectTimeout = null
+    }
+
     // Clean up current connection
     if (this.liveChat) {
       this.liveChat.stop()

--- a/packages/desktop/src/views/main/App.vue
+++ b/packages/desktop/src/views/main/App.vue
@@ -198,7 +198,7 @@ async function loadInitialData() {
   try {
     const recentMsgs = await rpc.request.getRecentMessages({})
     if (recentMsgs !== undefined && recentMsgs.length > 0) {
-      messages.value = [...recentMsgs].toReversed()
+      messages.value = [...recentMsgs]
     }
   } catch (error) {
     console.warn('[App] Failed to load recent messages:', error)

--- a/packages/desktop/src/views/main/App.vue
+++ b/packages/desktop/src/views/main/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, triggerRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import { usePolling } from './composables/usePolling'
 import { useRpcListener } from './composables/useRpcListener'
@@ -209,7 +209,8 @@ async function loadInitialData() {
     try {
       const msgs = await rpc.request.getWatchedChannelMessages({ id: ch.id })
       if (msgs && msgs.length > 0) {
-        watchedMessages.value = new Map(watchedMessages.value).set(ch.id, msgs)
+        watchedMessages.value.set(ch.id, msgs)
+        triggerRef(watchedMessages)
       }
     } catch {
       // Not fatal
@@ -264,11 +265,13 @@ const DOWNLOAD_IN_PROGRESS_STATUSES = new Set([
 ])
 
 useRpcListener('chat_message', (msg: NormalizedChatMessage) => {
-  messages.value = [msg, ...messages.value].slice(0, 500)
+  messages.value.unshift(msg)
+  if (messages.value.length > 500) messages.value.length = 500
 })
 
 useRpcListener('chat_event', (ev: NormalizedEvent) => {
-  events.value = [ev, ...events.value].slice(0, 200)
+  events.value.unshift(ev)
+  if (events.value.length > 200) events.value.length = 200
   if (activeTab.value !== 'events') {
     unreadEvents.value++
   }
@@ -333,10 +336,10 @@ useRpcListener(
   'watched_channel_message',
   ({ channelId, message }: { channelId: string; message: NormalizedChatMessage }) => {
     const prev = watchedMessages.value.get(channelId) ?? []
-    watchedMessages.value = new Map(watchedMessages.value).set(
-      channelId,
-      [message, ...prev].slice(0, 200),
-    )
+    prev.unshift(message)
+    if (prev.length > 200) prev.length = 200
+    watchedMessages.value.set(channelId, prev)
+    triggerRef(watchedMessages)
   },
 )
 

--- a/packages/desktop/src/views/main/App.vue
+++ b/packages/desktop/src/views/main/App.vue
@@ -265,13 +265,13 @@ const DOWNLOAD_IN_PROGRESS_STATUSES = new Set([
 ])
 
 useRpcListener('chat_message', (msg: NormalizedChatMessage) => {
-  messages.value.unshift(msg)
-  if (messages.value.length > 500) messages.value.length = 500
+  messages.value.push(msg)
+  if (messages.value.length > 500) messages.value.splice(0, messages.value.length - 500)
 })
 
 useRpcListener('chat_event', (ev: NormalizedEvent) => {
-  events.value.unshift(ev)
-  if (events.value.length > 200) events.value.length = 200
+  events.value.push(ev)
+  if (events.value.length > 200) events.value.splice(0, events.value.length - 200)
   if (activeTab.value !== 'events') {
     unreadEvents.value++
   }
@@ -336,8 +336,8 @@ useRpcListener(
   'watched_channel_message',
   ({ channelId, message }: { channelId: string; message: NormalizedChatMessage }) => {
     const prev = watchedMessages.value.get(channelId) ?? []
-    prev.unshift(message)
-    if (prev.length > 200) prev.length = 200
+    prev.push(message)
+    if (prev.length > 200) prev.splice(0, prev.length - 200)
     watchedMessages.value.set(channelId, prev)
     triggerRef(watchedMessages)
   },

--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -57,7 +57,7 @@ function onVListScroll(offset: number) {
 
 function scrollToBottom() {
   const len = activeMessages.value.length
-  if (len > 0) vlistRef.value?.scrollToIndex(len - 1)
+  if (len > 0) vlistRef.value?.scrollToIndex(len - 1, { align: 'end' })
 }
 
 const replyTarget = ref<NormalizedChatMessage | null>(null)
@@ -164,16 +164,24 @@ const { start: startPolling } = usePolling(fetchChannelStatuses, 10_000)
 
 onMounted(() => {
   startPolling()
+  scrollToBottom()
 })
 
 // Auto-scroll to bottom when new messages arrive and user is already at bottom
+let initialScrollDone = false
 watch(
   () => activeMessages.value.length,
-  () => {
+  (len) => {
+    if (!initialScrollDone && len > 0) {
+      initialScrollDone = true
+      scrollToBottom()
+      return
+    }
     if (isAtBottom.value) {
       scrollToBottom()
     }
   },
+  { flush: 'post' },
 )
 
 // Re-fetch immediately when channels change

--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { VList } from 'virtua/vue'
+import type { VListHandle } from 'virtua/vue'
 import ChatMessage from './ChatMessage.vue'
 import ChatInput from './ChatInput.vue'
 import Tooltip from './ui/Tooltip.vue'
@@ -7,7 +9,6 @@ import ChatAppearancePopover from './ui/ChatAppearancePopover.vue'
 import { rpc } from '../main'
 import { platformColor } from '../../shared/utils/platform'
 import { usePolling } from '../composables/usePolling'
-import { useChatScroll } from '../composables/useChatScroll'
 import type {
   Account,
   AppSettings,
@@ -44,8 +45,17 @@ const emit = defineEmits<{
   'header-dragend': []
 }>()
 
-const listEl = ref<HTMLElement | null>(null)
-const { isAtBottom, onScroll, scrollToBottom, scrollToBottomOnNewMessage } = useChatScroll(listEl)
+const vlistRef = ref<VListHandle | null>(null)
+const isAtBottom = ref(true)
+
+function onVListScroll(offset: number) {
+  // With :reverse="true", offset near 0 means at the bottom (latest messages)
+  isAtBottom.value = offset < 40
+}
+
+function scrollToBottom() {
+  vlistRef.value?.scrollToIndex(0)
+}
 
 const replyTarget = ref<NormalizedChatMessage | null>(null)
 const showMenu = ref(false)
@@ -149,10 +159,8 @@ async function fetchChannelStatuses() {
 
 const { start: startPolling } = usePolling(fetchChannelStatuses, 10_000)
 
-onMounted(async () => {
+onMounted(() => {
   startPolling()
-  await nextTick()
-  scrollToBottom(false)
 })
 
 // Re-fetch immediately when channels change
@@ -161,11 +169,6 @@ watch(allChannels, () => fetchChannelStatuses(), { deep: true })
 // ---- Scroll ----
 const hasAnyConnection = computed(() =>
   ['twitch', 'youtube', 'kick'].some((p) => props.statuses.get(p)?.status === 'connected'),
-)
-
-watch(
-  () => activeMessages.value.length,
-  () => void scrollToBottomOnNewMessage(),
 )
 
 function platformName(platform: string): string {
@@ -350,12 +353,18 @@ function onAppearanceChange(s: AppSettings) {
 
     <!-- Messages + scroll pill wrapper -->
     <div class="chat-list-wrapper">
-      <div ref="listEl" class="chat-list" @scroll="onScroll">
-        <template v-if="activeMessages.length > 0">
+      <VList
+        v-if="activeMessages.length > 0"
+        ref="vlistRef"
+        class="chat-list"
+        :data="activeMessages"
+        :reverse="true"
+        @scroll="onVListScroll"
+      >
+        <template #default="{ item }">
           <ChatMessage
-            v-for="msg in [...activeMessages].reverse()"
-            :key="msg.id"
-            :message="msg"
+            :key="item.id"
+            :message="item"
             :show-platform-color-stripe="settings?.showPlatformColorStripe"
             :show-platform-icon="settings?.showPlatformIcon"
             :show-timestamp="settings?.showTimestamp"
@@ -369,77 +378,77 @@ function onAppearanceChange(s: AppSettings) {
             @reply="onReply"
           />
         </template>
+      </VList>
 
-        <!-- Empty state -->
-        <div v-else class="empty-state">
-          <div class="empty-icon">
-            <svg
-              width="48"
-              height="48"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              opacity=".35"
-            >
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-            </svg>
-          </div>
-
-          <!-- Watched channel: just waiting -->
-          <template v-if="watchedChannel">
-            <p class="empty-title">
-              {{
-                watchedChannelStatus?.status === 'connecting'
-                  ? 'Connecting…'
-                  : watchedChannelStatus?.status === 'connected'
-                    ? 'No messages yet'
-                    : 'Connecting…'
-              }}
-            </p>
-            <p class="empty-hint">
-              Messages from <strong>{{ watchedChannel.displayName }}</strong> will appear here.
-            </p>
-          </template>
-
-          <!-- No accounts at all -->
-          <template v-else-if="accounts.length === 0 && !hasAnyConnection">
-            <p class="empty-title">No accounts connected</p>
-            <p class="empty-hint">Connect your streaming accounts to start reading chat.</p>
-            <button class="empty-action" @click="emit('go-to-platforms')">Go to Platforms →</button>
-          </template>
-
-          <!-- Accounts exist, but no active connection yet -->
-          <template v-else-if="!hasAnyConnection">
-            <p class="empty-title">Waiting for connection…</p>
-            <div class="empty-accounts">
-              <div
-                v-for="acc in accounts"
-                :key="acc.id"
-                class="empty-account-chip"
-                :style="{ '--chip-color': platformColor(acc.platform) }"
-              >
-                <img v-if="acc.avatarUrl" :src="acc.avatarUrl" class="chip-avatar" />
-                <span v-else class="chip-avatar-fallback">{{
-                  acc.displayName.charAt(0).toUpperCase()
-                }}</span>
-                <span class="chip-name">{{ acc.displayName }}</span>
-                <span class="chip-platform">{{ acc.platform }}</span>
-              </div>
-            </div>
-            <p class="empty-hint">Join a channel in <strong>Platforms</strong> to see chat.</p>
-          </template>
-
-          <!-- Connected, just no messages yet -->
-          <template v-else>
-            <p class="empty-title">No messages yet</p>
-            <p class="empty-hint">Chat messages will appear here in real time.</p>
-          </template>
+      <!-- Empty state -->
+      <div v-else class="empty-state chat-list">
+        <div class="empty-icon">
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            opacity=".35"
+          >
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
         </div>
+
+        <!-- Watched channel: just waiting -->
+        <template v-if="watchedChannel">
+          <p class="empty-title">
+            {{
+              watchedChannelStatus?.status === 'connecting'
+                ? 'Connecting…'
+                : watchedChannelStatus?.status === 'connected'
+                  ? 'No messages yet'
+                  : 'Connecting…'
+            }}
+          </p>
+          <p class="empty-hint">
+            Messages from <strong>{{ watchedChannel.displayName }}</strong> will appear here.
+          </p>
+        </template>
+
+        <!-- No accounts at all -->
+        <template v-else-if="accounts.length === 0 && !hasAnyConnection">
+          <p class="empty-title">No accounts connected</p>
+          <p class="empty-hint">Connect your streaming accounts to start reading chat.</p>
+          <button class="empty-action" @click="emit('go-to-platforms')">Go to Platforms →</button>
+        </template>
+
+        <!-- Accounts exist, but no active connection yet -->
+        <template v-else-if="!hasAnyConnection">
+          <p class="empty-title">Waiting for connection…</p>
+          <div class="empty-accounts">
+            <div
+              v-for="acc in accounts"
+              :key="acc.id"
+              class="empty-account-chip"
+              :style="{ '--chip-color': platformColor(acc.platform) }"
+            >
+              <img v-if="acc.avatarUrl" :src="acc.avatarUrl" class="chip-avatar" />
+              <span v-else class="chip-avatar-fallback">{{
+                acc.displayName.charAt(0).toUpperCase()
+              }}</span>
+              <span class="chip-name">{{ acc.displayName }}</span>
+              <span class="chip-platform">{{ acc.platform }}</span>
+            </div>
+          </div>
+          <p class="empty-hint">Join a channel in <strong>Platforms</strong> to see chat.</p>
+        </template>
+
+        <!-- Connected, just no messages yet -->
+        <template v-else>
+          <p class="empty-title">No messages yet</p>
+          <p class="empty-hint">Chat messages will appear here in real time.</p>
+        </template>
       </div>
-      <!-- /.chat-list -->
+      <!-- /empty-state -->
 
       <!-- Scroll-to-bottom pill -->
       <Transition name="fade">
@@ -739,10 +748,7 @@ function onAppearanceChange(s: AppSettings) {
 
 .chat-list {
   flex: 1;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  padding: 4px 0;
+  overflow: hidden;
 }
 
 /* Empty state */

--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -49,12 +49,15 @@ const vlistRef = ref<VListHandle | null>(null)
 const isAtBottom = ref(true)
 
 function onVListScroll(offset: number) {
-  // With :reverse="true", offset near 0 means at the bottom (latest messages)
-  isAtBottom.value = offset < 40
+  // offset = scrollTop from top. At bottom when scrollTop + viewportSize ≈ scrollSize.
+  const handle = vlistRef.value
+  if (!handle) return
+  isAtBottom.value = handle.scrollSize - offset - handle.viewportSize < 40
 }
 
 function scrollToBottom() {
-  vlistRef.value?.scrollToIndex(0)
+  const len = activeMessages.value.length
+  if (len > 0) vlistRef.value?.scrollToIndex(len - 1)
 }
 
 const replyTarget = ref<NormalizedChatMessage | null>(null)
@@ -162,6 +165,16 @@ const { start: startPolling } = usePolling(fetchChannelStatuses, 10_000)
 onMounted(() => {
   startPolling()
 })
+
+// Auto-scroll to bottom when new messages arrive and user is already at bottom
+watch(
+  () => activeMessages.value.length,
+  () => {
+    if (isAtBottom.value) {
+      scrollToBottom()
+    }
+  },
+)
 
 // Re-fetch immediately when channels change
 watch(allChannels, () => fetchChannelStatuses(), { deep: true })
@@ -358,7 +371,6 @@ function onAppearanceChange(s: AppSettings) {
         ref="vlistRef"
         class="chat-list"
         :data="activeMessages"
-        :reverse="true"
         @scroll="onVListScroll"
       >
         <template #default="{ item }">

--- a/packages/desktop/src/views/main/composables/useMessageParsing.ts
+++ b/packages/desktop/src/views/main/composables/useMessageParsing.ts
@@ -1,4 +1,4 @@
-import { computed, onMounted, reactive, type ComputedRef } from 'vue'
+import { computed, onMounted, type ComputedRef } from 'vue'
 
 import type { Emote, NormalizedChatMessage, Platform } from '@twirchat/shared/types'
 
@@ -7,7 +7,7 @@ import { rpc } from '../main'
 const URL_REGEX = /https?:\/\/[^\s<>"']+[^\s<>"'.,;:!?)\]]/g
 const MENTION_REGEX = /@([a-zA-Z0-9_]+)/g
 
-const mentionColorCache = reactive(new Map<string, string | null>())
+const mentionColorCache = new Map<string, string | null>()
 
 export interface MessagePart {
   type: 'text' | 'emote'
@@ -30,9 +30,15 @@ async function fetchMentionColor(platform: string, username: string): Promise<vo
       platform: platform as Platform,
       username,
     })
+    if (mentionColorCache.size > 2000) {
+      mentionColorCache.clear()
+    }
     mentionColorCache.set(key, color)
   } catch (error) {
     console.warn('[useMessageParsing] Failed to fetch color for:', platform, username, error)
+    if (mentionColorCache.size > 2000) {
+      mentionColorCache.clear()
+    }
     mentionColorCache.set(key, null)
   }
 }

--- a/packages/desktop/src/views/main/test-harness.html
+++ b/packages/desktop/src/views/main/test-harness.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chat Test Harness</title>
+  </head>
+  <body style="margin: 0; height: 100vh; display: flex; flex-direction: column">
+    <div id="harness" style="flex: 1; overflow: hidden"></div>
+    <script type="module" src="./test-harness.ts"></script>
+  </body>
+</html>

--- a/packages/desktop/src/views/main/test-harness.ts
+++ b/packages/desktop/src/views/main/test-harness.ts
@@ -1,0 +1,41 @@
+import { createApp, ref } from 'vue'
+import { VList } from 'virtua/vue'
+import type { NormalizedChatMessage } from '@twirchat/shared/types'
+
+function makeFakeMessage(i: number): NormalizedChatMessage {
+  return {
+    id: `test-${i}`,
+    platform: 'twitch',
+    channelId: 'test-channel',
+    author: {
+      id: `user-${i}`,
+      displayName: `User${i}`,
+      badges: [],
+    },
+    text: `Message #${i}: ${Array(5).fill('Lorem ipsum').join(' ')}`,
+    emotes: [],
+    timestamp: new Date(),
+    type: 'message',
+  }
+}
+
+const messages = ref<NormalizedChatMessage[]>(
+  Array.from({ length: 200 }, (_, i) => makeFakeMessage(i)),
+)
+
+createApp({
+  setup() {
+    return { messages }
+  },
+  template: `
+    <VList :data="messages" :reverse="true" style="height:100vh">
+      <template #default="{ item }">
+        <div style="padding:4px 8px;border-bottom:1px solid #333;">
+          <span style="color:#a78bfa;font-weight:600">{{ item.author.displayName }}:</span>
+          {{ item.text }}
+        </div>
+      </template>
+    </VList>
+  `,
+  components: { VList },
+}).mount('#harness')

--- a/packages/desktop/tests/fixtures/seed-chat.ts
+++ b/packages/desktop/tests/fixtures/seed-chat.ts
@@ -1,0 +1,37 @@
+import type { NormalizedChatMessage } from '@twirchat/shared/types'
+
+const ENDPOINT = 'http://localhost:45824/dev/inject-chat'
+const COUNT = 150
+
+for (let i = 0; i < COUNT; i++) {
+  const msg: NormalizedChatMessage = {
+    id: `seed-${Date.now()}-${i}`,
+    platform: 'twitch',
+    channelId: 'test',
+    author: {
+      id: `user-${i % 10}`,
+      username: `testuser${i % 10}`,
+      displayName: `TestUser${i % 10}`,
+      badges: [],
+    },
+    text: `Seed message #${i + 1}: Hello from seed-chat fixture`,
+    emotes: [],
+    timestamp: new Date(),
+    type: 'message',
+  }
+
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(msg),
+  })
+
+  if (!res.ok) {
+    console.error(`Failed to inject message ${i}: ${res.status}`)
+    process.exit(1)
+  }
+
+  await Bun.sleep(20)
+}
+
+console.log(`Injected ${COUNT} messages successfully`)


### PR DESCRIPTION
## Summary

Fixes 6 confirmed memory bugs in platform adapters and the Vue renderer, and replaces the `v-for` message list with a **virtua VList** for DOM virtualization.

### Platform Adapter Fixes

- **YouTube adapter** (`scheduleReconnect`): `clearTimeout` guard added before creating new timer — prevents stacking timers on rapid reconnects
- **Kick adapter** (`connectPusher`): `ws.close(); ws = null` teardown at entry — prevents orphaned WebSocket connections
- **Twitch adapter** (`connectChatClient`): `if (chatClient) { await quit(); chatClient = null }` guard — prevents two simultaneous IRC connections

### Vue Renderer Fixes

- **`useMessageParsing.ts`**: Removed `reactive()` from `mentionColorCache` (unnecessary overhead). Added `.size > 2000 → .clear()` cap to prevent unbounded Map growth
- **`App.vue`**: Replaced `[msg, ...arr].slice()` spread allocations with in-place `push` + `splice` trim on all 3 message buffers (`messages`, `events`, `watchedMessages`). Added `triggerRef(watchedMessages)` for correct reactivity on manual Map mutation

### DOM Virtualization (virtua VList)

- Replaced `v-for` over full message array in `ChatList.vue` with `virtua` **VList** — only visible rows are in the DOM
- Auto-scroll to bottom when new messages arrive (via `watch` on message count)
- Scroll pill + "scroll to latest" button working correctly via `scrollToIndex(length - 1)`
- `isAtBottom` detection uses `scrollSize - offset - viewportSize < 40px` threshold

### Bug Fixed Post-Review

- `virtua` VList has **no `:reverse` prop** (it was silently ignored). Fixed: use `push` (newest at end) + `scrollToIndex(last)`, not `unshift` + a non-existent `reverse` prop

## Testing

- `bun run check`: 0 errors (15 pre-existing backend warnings)
- `vue-tsc --noEmit`: clean
- `bun test tests/`: 61/61 pass
- Dev injection endpoint: `POST http://localhost:45824/dev/inject-chat` (gated by `NODE_ENV !== 'production'`)
- Seed fixture: `bun packages/desktop/tests/fixtures/seed-chat.ts` (150 messages)

## Memory Context

The ~400 MB seen in `htop` is dominated by **CEF (Chromium Embedded Framework)** shared pages (~150–300 MB) which are charged to the process but physically shared with the OS — not reducible without changing the rendering engine. The fixes address *growth*: without them, memory increases as messages accumulate; now message buffers are capped and the DOM node count stays bounded.