### PR TITLE
fix(seventv): snapshot clientSubs before iteration in cleanupClient

### DIFF
--- a/packages/backend/src/seventv/subscription-manager.ts
+++ b/packages/backend/src/seventv/subscription-manager.ts
@@ -174,7 +174,7 @@ export class SevenTVSubscriptionManager {
       return
     }
 
-    for (const sub of clientSubs) {
+    for (const sub of Array.from(clientSubs)) {
       this.unsubscribeClient(clientSecret, sub.platform, sub.channelId)
     }
   }


### PR DESCRIPTION
Iterating a Set while unsubscribeClient() mutates it via delete() could cause entries to be skipped. Snapshot with Array.from() first to ensure all subscriptions are cleaned up on client disconnect.