### PR TITLE
feat: user aliases (custom nicknames for chat users)

### DIFF
--- a/packages/desktop/src/bun/index.ts
+++ b/packages/desktop/src/bun/index.ts
@@ -42,6 +42,7 @@ import {
   SettingsStore,
   UsernameColorCache,
 } from '../store'
+import { UserAliasStore } from '../store/user-alias-store'
 import { BackendConnection } from '../backend-connection'
 import { ChatAggregator } from '../chat/aggregator'
 import { pushOverlayEvent, pushOverlayMessage, startOverlayServer } from '../overlay-server'
@@ -250,6 +251,19 @@ const rpc = defineElectrobunRPC<TwirChatRPCSchema>('bun', {
       },
 
       getChannels: () => ChannelStore.findAll(),
+
+      getUserAliases: () => UserAliasStore.findAll(),
+
+      setUserAlias: ({ platform, platformUserId, alias }) => {
+        if (!alias) {
+          UserAliasStore.remove(platform, platformUserId)
+        } else {
+          UserAliasStore.upsert(platform, platformUserId, alias)
+        }
+      },
+
+      removeUserAlias: ({ platform, platformUserId }) =>
+        UserAliasStore.remove(platform, platformUserId),
 
       authStart: async ({ platform }) => {
         if (platform === 'twitch') {

--- a/packages/desktop/src/shared/rpc.ts
+++ b/packages/desktop/src/shared/rpc.ts
@@ -39,6 +39,14 @@ import type {
 // Bun-side schema (what the webview calls into)
 // ----------------------------------------------------------------
 
+export interface UserAlias {
+  platform: Platform
+  platformUserId: string
+  alias: string
+  createdAt: number
+  updatedAt: number
+}
+
 type BunRequests = {
   /** Return all stored accounts */
   getAccounts: { params: void; response: Account[] }
@@ -46,6 +54,15 @@ type BunRequests = {
   getSettings: { params: void; response: AppSettings }
   /** Save app settings */
   saveSettings: { params: AppSettings; response: void }
+  /** Return all stored user aliases */
+  getUserAliases: { params: void; response: UserAlias[] }
+  /** Set (create or update) a user alias */
+  setUserAlias: {
+    params: { platform: Platform; platformUserId: string; alias: string }
+    response: void
+  }
+  /** Remove a user alias */
+  removeUserAlias: { params: { platform: Platform; platformUserId: string }; response: void }
   /** Return all persisted joined channels grouped by platform */
   getChannels: { params: void; response: Partial<Record<Platform, string[]>> }
   /** Start OAuth flow for a platform */

--- a/packages/desktop/src/store/db.ts
+++ b/packages/desktop/src/store/db.ts
@@ -100,5 +100,16 @@ function runMigrations(db: Database): void {
     )
   `)
 
+  db.run(`
+    CREATE TABLE IF NOT EXISTS user_aliases (
+      platform TEXT NOT NULL,
+      platform_user_id TEXT NOT NULL,
+      alias TEXT NOT NULL,
+      created_at INTEGER DEFAULT (unixepoch()),
+      updated_at INTEGER DEFAULT (unixepoch()),
+      PRIMARY KEY (platform, platform_user_id)
+    )
+  `)
+
   log.info('Migrations applied')
 }

--- a/packages/desktop/src/store/user-alias-store.ts
+++ b/packages/desktop/src/store/user-alias-store.ts
@@ -1,0 +1,56 @@
+import type { Platform } from '@twirchat/shared/types'
+import { getDb } from './db'
+
+interface DbRow {
+  platform: string
+  platform_user_id: string
+  alias: string
+  created_at: number
+  updated_at: number
+}
+
+export interface UserAlias {
+  platform: Platform
+  platformUserId: string
+  alias: string
+  createdAt: number
+  updatedAt: number
+}
+
+function mapRow(row: DbRow): UserAlias {
+  return {
+    platform: row.platform as Platform,
+    platformUserId: row.platform_user_id,
+    alias: row.alias,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+export const UserAliasStore = {
+  findAll(): UserAlias[] {
+    const db = getDb()
+    const rows = db.query<DbRow, []>('SELECT * FROM user_aliases').all()
+    return rows.map(mapRow)
+  },
+
+  upsert(platform: Platform, platformUserId: string, alias: string): void {
+    const db = getDb()
+    db.run(
+      `INSERT INTO user_aliases (platform, platform_user_id, alias)
+       VALUES (?, ?, ?)
+       ON CONFLICT(platform, platform_user_id) DO UPDATE SET
+         alias = ?,
+         updated_at = unixepoch()`,
+      [platform, platformUserId, alias, alias],
+    )
+  },
+
+  remove(platform: Platform, platformUserId: string): void {
+    const db = getDb()
+    db.run('DELETE FROM user_aliases WHERE platform = ? AND platform_user_id = ?', [
+      platform,
+      platformUserId,
+    ])
+  },
+}

--- a/packages/desktop/src/views/main/App.vue
+++ b/packages/desktop/src/views/main/App.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, triggerRef, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRpcListener } from './composables/useRpcListener'
 import { useAccountsStore } from './stores/accounts'
+import { useAliasStore } from './stores/useAliasStore'
 import { useSettingsStore } from './stores/settings'
 import { useChannelStatusStore } from './stores/channelStatus'
 import { useStreamStatusStore } from './stores/streamStatus'
@@ -36,6 +37,7 @@ import type {
 const messages = ref<NormalizedChatMessage[]>([])
 const events = ref<NormalizedEvent[]>([])
 const accountsStore = useAccountsStore()
+const aliasStore = useAliasStore()
 const settingsStore = useSettingsStore()
 const channelStatusStore = useChannelStatusStore()
 const streamStatusStore = useStreamStatusStore()
@@ -117,8 +119,9 @@ const youtubeAuthenticated = computed(() => accounts.value.some((a) => a.platfor
 
 async function loadInitialData() {
   try {
-    const [accs, setts, statList, watched] = await Promise.all([
+    const [accs, , setts, statList, watched] = await Promise.all([
       rpc.request.getAccounts(),
+      aliasStore.loadAliases(),
       rpc.request.getSettings(),
       rpc.request.getStatuses(),
       rpc.request.getWatchedChannels(),

--- a/packages/desktop/src/views/main/components/AutocompletePopup.vue
+++ b/packages/desktop/src/views/main/components/AutocompletePopup.vue
@@ -17,7 +17,11 @@ const emit = defineEmits<{
     <ul class="autocomplete-list">
       <li
         v-for="(suggestion, i) in suggestions"
-        :key="suggestion.label"
+        :key="
+          suggestion.type === 'mention'
+            ? `${suggestion.label}:${suggestion.insertLabel}`
+            : suggestion.label
+        "
         class="autocomplete-item"
         :class="{ 'is-selected': i === selectedIndex }"
         @mousedown.prevent="emit('select', i)"
@@ -28,6 +32,9 @@ const emit = defineEmits<{
             :style="{ backgroundColor: suggestion.color || '#8b8b99' }"
           ></span>
           <span class="mention-label">{{ suggestion.label }}</span>
+          <span v-if="suggestion.insertLabel !== suggestion.label" class="mention-real-name"
+            >→ {{ suggestion.insertLabel }}</span
+          >
         </template>
 
         <template v-else-if="suggestion.type === 'emote'">
@@ -98,6 +105,13 @@ const emit = defineEmits<{
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--c-text);
+}
+
+.mention-real-name {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--c-text-2);
+  white-space: nowrap;
 }
 
 .emote-image {

--- a/packages/desktop/src/views/main/components/ChatInput.vue
+++ b/packages/desktop/src/views/main/components/ChatInput.vue
@@ -10,6 +10,7 @@ import TwitchIcon from '../../../assets/icons/platforms/twitch.svg'
 import YoutubeIcon from '../../../assets/icons/platforms/youtube.svg'
 import KickIcon from '../../../assets/icons/platforms/kick.svg'
 import { parseToken, replaceToken, useAutocomplete } from '../composables/useAutocomplete'
+import { useAliasStore } from '../stores/useAliasStore'
 import AutocompletePopup from './AutocompletePopup.vue'
 import { PopoverContent, PopoverRoot, PopoverTrigger } from 'reka-ui'
 import EmotePicker from './EmotePicker.vue'
@@ -34,6 +35,7 @@ const emit = defineEmits<{
 
 const text = ref('')
 const textareaEl = ref<HTMLTextAreaElement | null>(null)
+const aliasStore = useAliasStore()
 
 const showEmotePicker = ref(false)
 const emotePickerRef = ref<InstanceType<typeof EmotePicker> | null>(null)
@@ -44,6 +46,7 @@ const { suggestions, isOpen, selectedIndex, mode, selectSuggestion, moveUp, move
     messages: computed(() => props.messages ?? []),
     watchedChannel: computed(() => props.watchedChannel ?? null),
     statuses: computed(() => props.statuses),
+    aliasMap: computed(() => aliasStore.aliasMap),
   })
 
 const currentChannelInfo = computed((): { platform: string; channelId: string } | null => {

--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -8,6 +8,7 @@ import Tooltip from './ui/Tooltip.vue'
 import ChatAppearancePopover from './ui/ChatAppearancePopover.vue'
 import { rpc } from '../main'
 import { platformColor } from '../../shared/utils/platform'
+import { useAliasStore } from '../stores/useAliasStore'
 import { useStreamStatusStore } from '../stores/streamStatus'
 import KickIcon from '../../../assets/icons/platforms/kick.svg'
 import TwitchIcon from '../../../assets/icons/platforms/twitch.svg'
@@ -71,11 +72,17 @@ function onReply(msg: NormalizedChatMessage) {
 }
 
 const streamStatusStore = useStreamStatusStore()
+const aliasStore = useAliasStore()
 
 function platformIcon(platform: string) {
   if (platform === 'twitch') return TwitchIcon
   if (platform === 'kick') return KickIcon
   return YoutubeIcon
+}
+
+function getAliasForMessage(msg: NormalizedChatMessage): string | undefined {
+  if (!msg.author.id) return undefined
+  return aliasStore.getAlias(msg.platform, msg.author.id)
 }
 
 const watchedStreamStatus = computed(() => {
@@ -383,6 +390,7 @@ function onAppearanceChange(s: AppSettings) {
           <ChatMessage
             :key="item.id"
             :message="item"
+            :alias="getAliasForMessage(item)"
             :show-platform-color-stripe="settings?.showPlatformColorStripe"
             :show-platform-icon="settings?.showPlatformIcon"
             :show-timestamp="settings?.showTimestamp"

--- a/packages/desktop/src/views/main/components/ChatMessage.vue
+++ b/packages/desktop/src/views/main/components/ChatMessage.vue
@@ -7,6 +7,7 @@ import { platformColor } from '../../shared/utils/platform'
 import TwitchIcon from '../../../assets/icons/platforms/twitch.svg'
 import YoutubeIcon from '../../../assets/icons/platforms/youtube.svg'
 import KickIcon from '../../../assets/icons/platforms/kick.svg'
+import UserContextMenu from './UserContextMenu.vue'
 import { useMessageParsing } from '../composables/useMessageParsing'
 import type { MessagePart } from '../composables/useMessageParsing'
 
@@ -22,6 +23,7 @@ const props = defineProps<{
   accounts?: Account[]
   selfPingEnabled?: boolean
   selfPingColor?: string
+  alias?: string
 }>()
 
 const emit = defineEmits<{
@@ -241,9 +243,22 @@ function scopeBadgeSvg(svgString: string, badgeId: string): string {
           />
           <span v-else class="badge-text">{{ badge.text }}</span>
         </span></span
-      ><span class="author" :style="message.author.color ? { color: message.author.color } : {}">{{
-        message.author.displayName
-      }}</span
+      ><template v-if="isSystemMessage"
+        ><span
+          class="author"
+          :style="message.author.color ? { color: message.author.color } : {}"
+          >{{ message.author.displayName }}</span
+        ></template
+      ><UserContextMenu
+        v-else
+        :platform="message.platform"
+        :platform-user-id="message.author.id"
+        :display-name="message.author.displayName"
+        :current-alias="props.alias"
+      >
+        <span class="author" :style="message.author.color ? { color: message.author.color } : {}">{{
+          props.alias ?? message.author.displayName
+        }}</span> </UserContextMenu
       ><span class="compact-sep">: </span
       ><span class="msg-text" :class="{ italic: message.type === 'action' }">
         <template v-for="(part, index) in messageParts" :key="index">
@@ -411,10 +426,26 @@ function scopeBadgeSvg(svgString: string, badgeId: string): string {
           </span>
         </span>
 
-        <!-- Author name -->
-        <span class="author" :style="message.author.color ? { color: message.author.color } : {}">{{
-          message.author.displayName
-        }}</span>
+        <template v-if="isSystemMessage">
+          <span
+            class="author"
+            :style="message.author.color ? { color: message.author.color } : {}"
+            >{{ message.author.displayName }}</span
+          >
+        </template>
+        <UserContextMenu
+          v-else
+          :platform="message.platform"
+          :platform-user-id="message.author.id"
+          :display-name="message.author.displayName"
+          :current-alias="props.alias"
+        >
+          <span
+            class="author"
+            :style="message.author.color ? { color: message.author.color } : {}"
+            >{{ props.alias ?? message.author.displayName }}</span
+          >
+        </UserContextMenu>
 
         <span v-if="props.showTimestamp" class="timestamp">{{
           formatTime(message.timestamp)
@@ -630,7 +661,7 @@ function scopeBadgeSvg(svgString: string, badgeId: string): string {
 .author {
   font-weight: 700;
   font-size: 0.9em;
-  cursor: default;
+  cursor: pointer;
 }
 
 .timestamp {

--- a/packages/desktop/src/views/main/components/UserContextMenu.vue
+++ b/packages/desktop/src/views/main/components/UserContextMenu.vue
@@ -118,61 +118,6 @@ async function handleRemoveAlias() {
 </template>
 
 <style scoped>
-.context-menu-content {
-  min-width: 160px;
-  background: var(--c-bg-2, #2a2a35);
-  border: 1px solid var(--c-border, #3a3a45);
-  border-radius: 6px;
-  padding: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  z-index: 1000;
-}
-
-.context-menu-label {
-  padding: 6px 10px;
-  font-size: 0.85em;
-  color: var(--c-text-2, #8b8b99);
-  font-weight: 600;
-}
-
-.context-menu-alias-label {
-  padding: 0 10px 6px;
-  font-size: 0.8em;
-  color: var(--c-accent, #9147ff);
-  font-style: italic;
-}
-
-.context-menu-item {
-  padding: 6px 10px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.9em;
-  color: var(--c-text, #e2e2e8);
-  outline: none;
-}
-
-.context-menu-item:hover,
-.context-menu-item[data-highlighted] {
-  background: var(--c-bg, #1e1e24);
-  color: var(--c-text, #e2e2e8);
-}
-
-.context-menu-item-danger {
-  color: #ff5050;
-}
-
-.context-menu-item-danger:hover,
-.context-menu-item-danger[data-highlighted] {
-  background: rgba(255, 80, 80, 0.15);
-  color: #ff5050;
-}
-
-.context-menu-separator {
-  height: 1px;
-  background: var(--c-border, #3a3a45);
-  margin: 4px 0;
-}
-
 .dialog-overlay {
   background: rgba(0, 0, 0, 0.6);
   position: fixed;
@@ -256,5 +201,64 @@ async function handleRemoveAlias() {
 
 .dialog-btn-save:hover {
   opacity: 0.9;
+}
+</style>
+
+<style>
+/* Global styles — ContextMenuContent is portalled outside the component tree */
+.context-menu-content {
+  min-width: 160px;
+  background-color: var(--c-surface-2, #1f1f24) !important;
+  border: 1px solid var(--c-border, #2a2a33);
+  border-radius: 6px;
+  padding: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  color-scheme: dark;
+}
+
+.context-menu-label {
+  padding: 6px 10px;
+  font-size: 0.85em;
+  color: var(--c-text-2, #8b8b99);
+  font-weight: 600;
+}
+
+.context-menu-alias-label {
+  padding: 0 10px 6px;
+  font-size: 0.8em;
+  color: var(--c-accent, #9147ff);
+  font-style: italic;
+}
+
+.context-menu-item {
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9em;
+  color: var(--c-text, #e2e2e8);
+  outline: none;
+}
+
+.context-menu-item:hover,
+.context-menu-item[data-highlighted] {
+  background: var(--c-bg, #1e1e24);
+  color: var(--c-text, #e2e2e8);
+}
+
+.context-menu-item-danger {
+  color: #ff5050;
+}
+
+.context-menu-item-danger:hover,
+.context-menu-item-danger[data-highlighted] {
+  background: rgba(255, 80, 80, 0.15);
+  color: #ff5050;
+}
+
+.context-menu-separator {
+  height: 1px;
+  background: var(--c-border, #2a2a33);
+  margin: 4px 0;
 }
 </style>

--- a/packages/desktop/src/views/main/components/UserContextMenu.vue
+++ b/packages/desktop/src/views/main/components/UserContextMenu.vue
@@ -1,0 +1,260 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRoot,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+} from 'reka-ui'
+import type { Platform } from '@twirchat/shared/types'
+import { useAliasStore } from '../stores/useAliasStore'
+
+interface Props {
+  platform: Platform
+  platformUserId: string
+  displayName: string
+  currentAlias?: string
+}
+
+const props = defineProps<Props>()
+
+const aliasStore = useAliasStore()
+const dialogOpen = ref(false)
+const aliasValue = ref('')
+const aliasInput = ref<HTMLInputElement | null>(null)
+
+function openDialog() {
+  aliasValue.value = props.currentAlias ?? ''
+  dialogOpen.value = true
+}
+
+function focusInput() {
+  aliasInput.value?.focus()
+}
+
+async function handleSaveAlias() {
+  const val = aliasValue.value.trim()
+  if (!val) {
+    await aliasStore.removeAlias(props.platform, props.platformUserId)
+  } else {
+    await aliasStore.setAlias(props.platform, props.platformUserId, val)
+  }
+  dialogOpen.value = false
+}
+
+async function handleRemoveAlias() {
+  await aliasStore.removeAlias(props.platform, props.platformUserId)
+}
+</script>
+
+<template>
+  <ContextMenuRoot>
+    <ContextMenuTrigger as-child>
+      <slot />
+    </ContextMenuTrigger>
+    <ContextMenuPortal>
+      <ContextMenuContent class="context-menu-content">
+        <!-- Header -->
+        <ContextMenuLabel class="context-menu-label">
+          {{ displayName }} ({{ platform }})
+        </ContextMenuLabel>
+
+        <ContextMenuSeparator class="context-menu-separator" />
+
+        <!-- Show current alias if set -->
+        <ContextMenuLabel v-if="currentAlias" class="context-menu-alias-label">
+          Alias: {{ currentAlias }}
+        </ContextMenuLabel>
+
+        <!-- Set/Edit alias → opens Dialog -->
+        <ContextMenuItem class="context-menu-item" @select="openDialog">
+          {{ currentAlias ? 'Edit alias' : 'Set alias' }}
+        </ContextMenuItem>
+
+        <!-- Remove alias → only shown if alias is set -->
+        <ContextMenuItem
+          v-if="currentAlias"
+          class="context-menu-item context-menu-item-danger"
+          @select="handleRemoveAlias"
+        >
+          Remove alias
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenuPortal>
+  </ContextMenuRoot>
+
+  <!-- Alias edit Dialog — separate from ContextMenu -->
+  <DialogRoot v-model:open="dialogOpen">
+    <DialogPortal>
+      <DialogOverlay class="dialog-overlay" />
+      <DialogContent class="dialog-content" @open-auto-focus="focusInput">
+        <h3 class="dialog-title">Set alias for {{ displayName }}</h3>
+        <p class="dialog-description">
+          Replaces the displayed name in chat. Leave empty to remove alias.
+        </p>
+        <input
+          ref="aliasInput"
+          v-model="aliasValue"
+          class="dialog-input"
+          :placeholder="displayName"
+          maxlength="50"
+          @keydown.enter.prevent="handleSaveAlias"
+          @keydown.escape.prevent="dialogOpen = false"
+        />
+        <div class="dialog-actions">
+          <button class="dialog-btn-cancel" @click="dialogOpen = false">Cancel</button>
+          <button class="dialog-btn-save" @click="handleSaveAlias">Save</button>
+        </div>
+      </DialogContent>
+    </DialogPortal>
+  </DialogRoot>
+</template>
+
+<style scoped>
+.context-menu-content {
+  min-width: 160px;
+  background: var(--c-bg-2, #2a2a35);
+  border: 1px solid var(--c-border, #3a3a45);
+  border-radius: 6px;
+  padding: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+}
+
+.context-menu-label {
+  padding: 6px 10px;
+  font-size: 0.85em;
+  color: var(--c-text-2, #8b8b99);
+  font-weight: 600;
+}
+
+.context-menu-alias-label {
+  padding: 0 10px 6px;
+  font-size: 0.8em;
+  color: var(--c-accent, #9147ff);
+  font-style: italic;
+}
+
+.context-menu-item {
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9em;
+  color: var(--c-text, #e2e2e8);
+  outline: none;
+}
+
+.context-menu-item:hover,
+.context-menu-item[data-highlighted] {
+  background: var(--c-bg, #1e1e24);
+  color: var(--c-text, #e2e2e8);
+}
+
+.context-menu-item-danger {
+  color: #ff5050;
+}
+
+.context-menu-item-danger:hover,
+.context-menu-item-danger[data-highlighted] {
+  background: rgba(255, 80, 80, 0.15);
+  color: #ff5050;
+}
+
+.context-menu-separator {
+  height: 1px;
+  background: var(--c-border, #3a3a45);
+  margin: 4px 0;
+}
+
+.dialog-overlay {
+  background: rgba(0, 0, 0, 0.6);
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+}
+
+.dialog-content {
+  background: var(--c-bg-2, #2a2a35);
+  border: 1px solid var(--c-border, #3a3a45);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 90vw;
+  max-width: 320px;
+  padding: 20px;
+  z-index: 2001;
+}
+
+.dialog-title {
+  margin: 0 0 8px;
+  font-size: 1.1em;
+  color: var(--c-text, #e2e2e8);
+}
+
+.dialog-description {
+  margin: 0 0 16px;
+  font-size: 0.9em;
+  color: var(--c-text-2, #8b8b99);
+}
+
+.dialog-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 12px;
+  background: var(--c-bg, #1e1e24);
+  border: 1px solid var(--c-border, #3a3a45);
+  color: var(--c-text, #e2e2e8);
+  border-radius: 4px;
+  margin-bottom: 20px;
+  font-size: 0.95em;
+}
+
+.dialog-input:focus {
+  outline: none;
+  border-color: var(--c-accent, #9147ff);
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.dialog-btn-cancel,
+.dialog-btn-save {
+  padding: 6px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: none;
+  font-weight: 500;
+  font-size: 0.9em;
+}
+
+.dialog-btn-cancel {
+  background: transparent;
+  color: var(--c-text, #e2e2e8);
+}
+
+.dialog-btn-cancel:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dialog-btn-save {
+  background: var(--c-accent, #9147ff);
+  color: #fff;
+}
+
+.dialog-btn-save:hover {
+  opacity: 0.9;
+}
+</style>

--- a/packages/desktop/src/views/main/composables/useAutocomplete.ts
+++ b/packages/desktop/src/views/main/composables/useAutocomplete.ts
@@ -2,6 +2,7 @@ import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
 
 import type {
   NormalizedChatMessage,
+  Platform,
   PlatformStatusInfo,
   WatchedChannel,
 } from '@twirchat/shared/types'
@@ -27,6 +28,7 @@ export function useAutocomplete(params: {
   messages: Ref<NormalizedChatMessage[]>
   watchedChannel: Ref<WatchedChannel | null | undefined>
   statuses: Ref<Map<string, PlatformStatusInfo>>
+  aliasMap?: Ref<Map<Platform, Map<string, string>>>
 }): {
   suggestions: ComputedRef<AutocompleteSuggestion[]>
   isOpen: ComputedRef<boolean>
@@ -37,7 +39,7 @@ export function useAutocomplete(params: {
   moveDown: () => void
   close: () => void
 } {
-  const { text, messages, watchedChannel, statuses } = params
+  const { text, messages, watchedChannel, statuses, aliasMap } = params
 
   const emoteStore = useEmoteStore()
   const closedQuery = ref('')
@@ -52,13 +54,23 @@ export function useAutocomplete(params: {
     const result: MentionSuggestion[] = []
 
     for (const msg of messages.value) {
-      const lower = msg.author.displayName.toLowerCase()
-      if (seen.has(lower)) continue
-      seen.add(lower)
+      const displayName = msg.author.displayName
+      const lower = displayName.toLowerCase()
+      const dedupKey = msg.author.id
+        ? `${msg.platform}:${msg.author.id}`
+        : `${msg.platform}:${lower}`
+
+      if (seen.has(dedupKey)) continue
+      seen.add(dedupKey)
+
+      const alias = msg.author.id
+        ? aliasMap?.value.get(msg.platform)?.get(msg.author.id)
+        : undefined
 
       result.push({
         type: 'mention',
-        label: msg.author.displayName,
+        label: alias || displayName,
+        insertLabel: displayName,
         color: mentionColorCache.get(`${msg.platform}:${lower}`) ?? null,
       })
     }

--- a/packages/desktop/src/views/main/stores/useAliasStore.ts
+++ b/packages/desktop/src/views/main/stores/useAliasStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { Platform } from '@twirchat/shared/types'
-import type { UserAlias } from '../../shared/rpc'
+import type { UserAlias } from '../../../shared/rpc'
 import { rpc } from '../main'
 
 export const useAliasStore = defineStore('aliases', () => {
@@ -41,8 +41,9 @@ export const useAliasStore = defineStore('aliases', () => {
       const idx = aliases.value.findIndex(
         (a) => a.platform === platform && a.platformUserId === platformUserId,
       )
-      if (idx >= 0) {
-        aliases.value[idx] = { ...aliases.value[idx], alias }
+      if (idx >= 0 && aliases.value[idx]) {
+        aliases.value[idx]!.alias = alias
+        aliases.value[idx]!.updatedAt = Date.now()
       } else {
         aliases.value.push({
           platform,

--- a/packages/desktop/src/views/main/stores/useAliasStore.ts
+++ b/packages/desktop/src/views/main/stores/useAliasStore.ts
@@ -1,0 +1,66 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import type { Platform } from '@twirchat/shared/types'
+import type { UserAlias } from '../../shared/rpc'
+import { rpc } from '../main'
+
+export const useAliasStore = defineStore('aliases', () => {
+  const aliases = ref<UserAlias[]>([])
+
+  // Nested map: platform → platformUserId → alias string
+  // O(1) lookup per message render
+  const aliasMap = computed(() => {
+    const map = new Map<Platform, Map<string, string>>()
+    for (const a of aliases.value) {
+      if (!map.has(a.platform)) map.set(a.platform, new Map())
+      map.get(a.platform)!.set(a.platformUserId, a.alias)
+    }
+    return map
+  })
+
+  function getAlias(platform: Platform, platformUserId: string): string | undefined {
+    return aliasMap.value.get(platform)?.get(platformUserId)
+  }
+
+  async function loadAliases(): Promise<void> {
+    const result = await rpc.request.getUserAliases()
+    if (result !== undefined) aliases.value = result
+  }
+
+  async function setAlias(
+    platform: Platform,
+    platformUserId: string,
+    alias: string,
+  ): Promise<void> {
+    await rpc.request.setUserAlias({ platform, platformUserId, alias })
+    if (!alias) {
+      aliases.value = aliases.value.filter(
+        (a) => !(a.platform === platform && a.platformUserId === platformUserId),
+      )
+    } else {
+      const idx = aliases.value.findIndex(
+        (a) => a.platform === platform && a.platformUserId === platformUserId,
+      )
+      if (idx >= 0) {
+        aliases.value[idx] = { ...aliases.value[idx], alias }
+      } else {
+        aliases.value.push({
+          platform,
+          platformUserId,
+          alias,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        })
+      }
+    }
+  }
+
+  async function removeAlias(platform: Platform, platformUserId: string): Promise<void> {
+    await rpc.request.removeUserAlias({ platform, platformUserId })
+    aliases.value = aliases.value.filter(
+      (a) => !(a.platform === platform && a.platformUserId === platformUserId),
+    )
+  }
+
+  return { aliases, aliasMap, getAlias, loadAliases, setAlias, removeAlias }
+})

--- a/packages/desktop/src/views/main/utils/autocompleteUtils.ts
+++ b/packages/desktop/src/views/main/utils/autocompleteUtils.ts
@@ -1,6 +1,7 @@
 export interface MentionSuggestion {
   type: 'mention'
   label: string
+  insertLabel: string
   color: string | null
 }
 
@@ -45,7 +46,7 @@ export function replaceToken(text: string, suggestion: AutocompleteSuggestion): 
   const before = text.slice(0, match.index)
 
   if (suggestion.type === 'mention') {
-    return `${before}@${suggestion.label} `
+    return `${before}@${suggestion.insertLabel} `
   }
 
   return `${before}${suggestion.label} `

--- a/packages/desktop/tests/store.test.ts
+++ b/packages/desktop/tests/store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { getDb, initDb } from '@desktop/store/db'
 import { AccountStore } from '@desktop/store/account-store'
 import { SettingsStore } from '@desktop/store/settings-store'
+import { UserAliasStore } from '@desktop/store/user-alias-store'
 import { DEFAULT_SETTINGS } from '@twirchat/shared/types'
 import { existsSync, unlinkSync } from 'node:fs'
 
@@ -186,5 +187,69 @@ describe('SettingsStore', () => {
     SettingsStore.update({ theme: 'light' })
     const settings = SettingsStore.get()
     expect(settings.theme).toBe('light')
+  })
+})
+
+describe('UserAliasStore', () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DB)) {
+      unlinkSync(TEST_DB)
+    }
+    initDb(TEST_DB)
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DB)) {
+      unlinkSync(TEST_DB)
+    }
+  })
+
+  test('creates user_aliases table on init', () => {
+    const db = getDb()
+    const tables = db
+      .query<{ name: string }, []>(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+      )
+      .all()
+      .map((r) => r.name)
+
+    expect(tables).toContain('user_aliases')
+  })
+
+  test('findAll returns empty array on fresh DB', () => {
+    const aliases = UserAliasStore.findAll()
+    expect(aliases).toEqual([])
+  })
+
+  test('upsert creates new alias', () => {
+    UserAliasStore.upsert('twitch', 'user123', 'CoolStreamer')
+    const aliases = UserAliasStore.findAll()
+    expect(aliases.length).toBe(1)
+    expect(aliases[0].platform).toBe('twitch')
+    expect(aliases[0].platformUserId).toBe('user123')
+    expect(aliases[0].alias).toBe('CoolStreamer')
+  })
+
+  test('upsert updates existing alias (same platform+userId)', () => {
+    UserAliasStore.upsert('twitch', 'user123', 'OldAlias')
+    UserAliasStore.upsert('twitch', 'user123', 'NewAlias')
+    const aliases = UserAliasStore.findAll()
+    expect(aliases.length).toBe(1)
+    expect(aliases[0].alias).toBe('NewAlias')
+  })
+
+  test('remove deletes alias', () => {
+    UserAliasStore.upsert('kick', 'user456', 'SomeAlias')
+    UserAliasStore.remove('kick', 'user456')
+    const aliases = UserAliasStore.findAll()
+    expect(aliases.length).toBe(0)
+  })
+
+  test('findAll returns all aliases', () => {
+    UserAliasStore.upsert('twitch', 'user1', 'Alias1')
+    UserAliasStore.upsert('kick', 'user2', 'Alias2')
+    UserAliasStore.upsert('youtube', 'user3', 'Alias3')
+    const aliases = UserAliasStore.findAll()
+    expect(aliases.length).toBe(3)
   })
 })


### PR DESCRIPTION
resolves #2

## Summary

Adds the ability to assign custom aliases (nicknames) to chat users. Right-click any username → set an alias → it persists in SQLite and displays in place of the real username everywhere in the chat.

## Changes

### 🗄️ Storage & Backend
- **SQLite migration**: new `user_aliases` table `(platform, platform_user_id, alias)` with a unique constraint
- **`UserAliasStore`** (`packages/desktop/src/store/user-alias-store.ts`): CRUD methods (`getAliases`, `setAlias`, `removeAlias`) backed by `bun:sqlite`
- **RPC handlers** (`src/shared/rpc.ts` + `src/bun/index.ts`): three new IPC calls — `getUserAliases`, `setUserAlias`, `removeUserAlias`
- **Tests** (`tests/store.test.ts`): full coverage of set/get/remove/clear alias logic

### 🧩 Frontend State
- **`useAliasStore`** (Pinia): loads all aliases on startup, exposes `aliasMap: Map<Platform, Map<userId, alias>>` for O(1) lookup; wired in `App.vue`

### 💬 Chat Display
- **`ChatMessage.vue`**: resolves alias from `useAliasStore` and displays it instead of `displayName`; original name shown in tooltip
- **`ChatList.vue`**: passes `aliasMap` down to each message

### 🖱️ Context Menu
- **`UserContextMenu.vue`**: right-click on any username opens a context menu with a text input to set/clear alias; empty submit removes the alias
- **Fix**: moved portalled (reka-ui `ContextMenuPortal`) styles from `<style scoped>` to a global `<style>` block — scoped attributes don't propagate through portal DOM teleportation, causing the transparent background bug

### ⌨️ Mention Autocomplete
- **`autocompleteUtils.ts`**: `MentionSuggestion` gains `insertLabel` (the real display name to insert) separate from `label` (what's shown in the popup — alias if set)
- **`useAutocomplete.ts`**: if a user has an alias, the suggestion shows the alias as `label` but inserts the real nick; deduplication by `platform:userId`
- **`ChatInput.vue`**: wires `aliasMap` from `useAliasStore` into `useAutocomplete`
- **`AutocompletePopup.vue`**: shows `→ RealNick` next to the alias when they differ

## Commits

| Commit | Description |
|--------|-------------|
| `6c2eb5d` | feat(store): add user_aliases table and UserAliasStore with tests |
| `8886254` | feat(store): add useAliasStore Pinia store, load at startup |
| `9445ca2` | feat(rpc): add getUserAliases, setUserAlias, removeUserAlias handlers |
| `37c0dd5` | feat(ui): add user alias context menu and chat display |
| `3235000` | fix(ui): fix transparent context menu by moving portalled styles to global block |
| `2682fc9` | feat(ui): alias-aware mention autocomplete — suggest by alias, insert real nick |

## Constraints

- Overlay (`src/views/overlay/`) is intentionally **not** modified — it's a separate Vite app out of scope
- `NormalizedChatMessage` shape in `@twirchat/shared` is **unchanged**
- No `bun:sqlite` imports in any `src/views/` file
- No `as any` TypeScript casts