### PR TITLE
fix(backend): recover Twitch 7TV and Helix lookups

### DIFF
--- a/packages/backend/src/api/channels-status.ts
+++ b/packages/backend/src/api/channels-status.ts
@@ -17,7 +17,7 @@
  */
 
 import { config } from '../config.ts'
-import { getKickAppToken, getTwitchAppToken } from './stream-status.ts'
+import { fetchTwitchHelixWithAppToken, getKickAppToken } from './stream-status.ts'
 import {
   isTwitchUserId,
   normalizeTwitchLogin,
@@ -67,12 +67,12 @@ async function fetchTwitchChannelsStatus(
 
   // Prefer user token from first channel that has one. Fall back to app token.
   const userToken = channels.find((c) => c.userAccessToken)?.userAccessToken
-  const token = userToken ?? (await getTwitchAppToken())
-
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    'Client-Id': config.TWITCH_CLIENT_ID,
-  }
+  const headers = userToken
+    ? {
+        Authorization: `Bearer ${userToken}`,
+        'Client-Id': config.TWITCH_CLIENT_ID,
+      }
+    : undefined
 
   const loginToId = new Map<string, string>()
   for (const channel of normalizedChannels) {
@@ -88,7 +88,7 @@ async function fetchTwitchChannelsStatus(
 
   if (loginsNeedingResolution.length > 0) {
     try {
-      const resolvedUsers = await resolveTwitchUserIdsByLogin(loginsNeedingResolution, token)
+      const resolvedUsers = await resolveTwitchUserIdsByLogin(loginsNeedingResolution, userToken)
       for (const [login, id] of resolvedUsers) {
         loginToId.set(login, id)
       }
@@ -120,10 +120,19 @@ async function fetchTwitchChannelsStatus(
     .join('&')
   const idParams = broadcasterIds.map((id) => `broadcaster_id=${encodeURIComponent(id)}`).join('&')
 
-  const [streamsRes, channelsRes] = await Promise.all([
-    fetch(`https://api.twitch.tv/helix/streams?${loginParams}&first=100`, { headers }),
-    fetch(`https://api.twitch.tv/helix/channels?${idParams}`, { headers }),
-  ])
+  const [streamsRes, channelsRes] = await Promise.all(
+    userToken
+      ? [
+          fetch(`https://api.twitch.tv/helix/streams?${loginParams}&first=100`, { headers }),
+          fetch(`https://api.twitch.tv/helix/channels?${idParams}`, { headers }),
+        ]
+      : [
+          fetchTwitchHelixWithAppToken(
+            `https://api.twitch.tv/helix/streams?${loginParams}&first=100`,
+          ),
+          fetchTwitchHelixWithAppToken(`https://api.twitch.tv/helix/channels?${idParams}`),
+        ],
+  )
 
   const liveMap = new Map<string, HelixStream>()
   const offlineMap = new Map<string, HelixChannel>()

--- a/packages/backend/src/api/search-categories.ts
+++ b/packages/backend/src/api/search-categories.ts
@@ -8,23 +8,15 @@
 
 import { config } from '../config.ts'
 import type { CategorySearchResult, SearchCategoriesResponse } from '@twirchat/shared'
-import { getKickAppToken, getTwitchAppToken } from './stream-status.ts'
+import { fetchTwitchHelixWithAppToken, getKickAppToken } from './stream-status.ts'
 
 // ----------------------------------------------------------------
 // Twitch
 // ----------------------------------------------------------------
 
 async function searchTwitchCategories(query: string): Promise<CategorySearchResult[]> {
-  const token = await getTwitchAppToken()
-
-  const res = await fetch(
+  const res = await fetchTwitchHelixWithAppToken(
     `https://api.twitch.tv/helix/search/categories?query=${encodeURIComponent(query)}&first=25`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Client-Id': config.TWITCH_CLIENT_ID,
-      },
-    },
   )
 
   if (!res.ok) {

--- a/packages/backend/src/api/stream-status.ts
+++ b/packages/backend/src/api/stream-status.ts
@@ -18,6 +18,19 @@ import type { StreamStatusResponse } from '@twirchat/shared'
 let twitchAppToken: string | null = null
 let twitchAppTokenExpiresAt = 0
 
+function invalidateTwitchAppToken(): void {
+  twitchAppToken = null
+  twitchAppTokenExpiresAt = 0
+}
+
+function getTwitchHelixHeaders(token: string, headers?: RequestInit['headers']): Headers {
+  const nextHeaders = new Headers(headers)
+  nextHeaders.set('Authorization', `Bearer ${token}`)
+  nextHeaders.set('Client-Id', config.TWITCH_CLIENT_ID)
+
+  return nextHeaders
+}
+
 async function getTwitchAppToken(): Promise<string> {
   if (twitchAppToken && Date.now() < twitchAppTokenExpiresAt - 60_000) {
     return twitchAppToken
@@ -47,6 +60,29 @@ async function getTwitchAppToken(): Promise<string> {
   twitchAppTokenExpiresAt = Date.now() + data.expires_in * 1000
 
   return twitchAppToken
+}
+
+async function fetchTwitchHelixWithAppToken(
+  input: string | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const token = await getTwitchAppToken()
+  const response = await fetch(input, {
+    ...init,
+    headers: getTwitchHelixHeaders(token, init.headers),
+  })
+
+  if (response.status !== 401) {
+    return response
+  }
+
+  invalidateTwitchAppToken()
+
+  const refreshedToken = await getTwitchAppToken()
+  return fetch(input, {
+    ...init,
+    headers: getTwitchHelixHeaders(refreshedToken, init.headers),
+  })
 }
 
 // ----------------------------------------------------------------
@@ -92,17 +128,9 @@ async function getKickAppToken(): Promise<string> {
 // ----------------------------------------------------------------
 
 async function getTwitchStreamStatus(channelId: string): Promise<StreamStatusResponse> {
-  const token = await getTwitchAppToken()
-
   // First, try to get live stream data
-  const streamRes = await fetch(
+  const streamRes = await fetchTwitchHelixWithAppToken(
     `https://api.twitch.tv/helix/streams?user_id=${encodeURIComponent(channelId)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Client-Id': config.TWITCH_CLIENT_ID,
-      },
-    },
   )
 
   if (!streamRes.ok) {
@@ -130,14 +158,8 @@ async function getTwitchStreamStatus(channelId: string): Promise<StreamStatusRes
   }
 
   // Offline: fetch channel info for title/game
-  const channelRes = await fetch(
+  const channelRes = await fetchTwitchHelixWithAppToken(
     `https://api.twitch.tv/helix/channels?broadcaster_id=${encodeURIComponent(channelId)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Client-Id': config.TWITCH_CLIENT_ID,
-      },
-    },
   )
 
   if (!channelRes.ok) {
@@ -240,4 +262,4 @@ export async function handleStreamStatus(url: URL): Promise<StreamStatusResponse
 }
 
 // Re-export app token helpers for use in other API modules
-export { getTwitchAppToken, getKickAppToken }
+export { fetchTwitchHelixWithAppToken, getKickAppToken, getTwitchAppToken }

--- a/packages/backend/src/api/twitch-badges.ts
+++ b/packages/backend/src/api/twitch-badges.ts
@@ -9,10 +9,9 @@
  * Example: { "subscriber/6": "https://static-cdn.jtvnw.net/badges/v1/<uuid>/1" }
  */
 
-import { config } from '../config.ts'
-import { getTwitchAppToken } from './stream-status.ts'
 import { logger } from '@twirchat/shared/logger'
 import type { TwitchBadgesResponse } from '@twirchat/shared'
+import { fetchTwitchHelixWithAppToken } from './stream-status.ts'
 
 const log = logger('twitch-badges')
 
@@ -38,17 +37,13 @@ function mergeHelixBadges(result: Record<string, string>, body: HelixBadgesBody)
 
 export async function handleTwitchBadges(url: URL): Promise<TwitchBadgesResponse> {
   const broadcasterLogin = url.searchParams.get('broadcasterLogin')
-  const token = await getTwitchAppToken()
-
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    'Client-Id': config.TWITCH_CLIENT_ID,
-  }
 
   const badges: Record<string, string> = {}
 
   // 1. Global badges
-  const globalRes = await fetch('https://api.twitch.tv/helix/chat/badges/global', { headers })
+  const globalRes = await fetchTwitchHelixWithAppToken(
+    'https://api.twitch.tv/helix/chat/badges/global',
+  )
   if (!globalRes.ok) {
     throw new Error(`Helix global badges failed: ${globalRes.status}`)
   }
@@ -61,17 +56,15 @@ export async function handleTwitchBadges(url: URL): Promise<TwitchBadgesResponse
   // 2. Channel-specific badges (subscriber tiers, bits, custom, etc.)
   if (broadcasterLogin) {
     // Resolve login → broadcaster_id
-    const userRes = await fetch(
+    const userRes = await fetchTwitchHelixWithAppToken(
       `https://api.twitch.tv/helix/users?login=${encodeURIComponent(broadcasterLogin)}`,
-      { headers },
     )
     if (userRes.ok) {
       const userData = (await userRes.json()) as { data: { id: string }[] }
       const broadcasterId = userData.data[0]?.id
       if (broadcasterId) {
-        const chanRes = await fetch(
+        const chanRes = await fetchTwitchHelixWithAppToken(
           `https://api.twitch.tv/helix/chat/badges?broadcaster_id=${broadcasterId}`,
-          { headers },
         )
         if (chanRes.ok) {
           const chanBody = (await chanRes.json()) as HelixBadgesBody

--- a/packages/backend/src/api/twitch-users.ts
+++ b/packages/backend/src/api/twitch-users.ts
@@ -1,5 +1,5 @@
 import { config } from '../config.ts'
-import { getTwitchAppToken } from './stream-status.ts'
+import { fetchTwitchHelixWithAppToken } from './stream-status.ts'
 
 export interface HelixUser {
   id: string
@@ -30,6 +30,23 @@ export function isTwitchUserId(id: string | undefined | null): id is string {
   return Boolean(id && TWITCH_USER_ID_RE.test(id))
 }
 
+export async function resolveTwitchUserId(
+  identifier: string,
+  userAccessToken?: string,
+): Promise<string | null> {
+  if (isTwitchUserId(identifier)) {
+    return identifier
+  }
+
+  const normalizedLogin = normalizeTwitchLogin(identifier)
+  if (!normalizedLogin) {
+    return null
+  }
+
+  const resolvedUsers = await resolveTwitchUserIdsByLogin([normalizedLogin], userAccessToken)
+  return resolvedUsers.get(normalizedLogin) ?? null
+}
+
 export async function resolveTwitchUserIdsByLogin(
   logins: string[],
   userAccessToken?: string,
@@ -43,14 +60,16 @@ export async function resolveTwitchUserIdsByLogin(
     return loginToId
   }
 
-  const token = userAccessToken ?? (await getTwitchAppToken())
   const params = normalizedLogins.map((login) => `login=${encodeURIComponent(login)}`).join('&')
-  const response = await fetch(`https://api.twitch.tv/helix/users?${params}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Client-Id': config.TWITCH_CLIENT_ID,
-    },
-  })
+  const url = `https://api.twitch.tv/helix/users?${params}`
+  const response = userAccessToken
+    ? await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${userAccessToken}`,
+          'Client-Id': config.TWITCH_CLIENT_ID,
+        },
+      })
+    : await fetchTwitchHelixWithAppToken(url)
 
   if (!response.ok) {
     const body = await response.text()

--- a/packages/backend/src/seventv/subscription-manager.ts
+++ b/packages/backend/src/seventv/subscription-manager.ts
@@ -1,10 +1,6 @@
 import type { Platform } from '@twirchat/shared'
 import { logger } from '@twirchat/shared/logger'
-import {
-  isTwitchUserId,
-  normalizeTwitchLogin,
-  resolveTwitchUserIdsByLogin,
-} from '../api/twitch-users.ts'
+import { isTwitchUserId, resolveTwitchUserId } from '../api/twitch-users.ts'
 import { sevenTVCache } from './cache'
 import type { SevenTVEmote } from './cache'
 import { sevenTVEventClient } from './event-client'
@@ -198,24 +194,19 @@ export class SevenTVSubscriptionManager {
 
     let sevenTVPlatformId = channelId
     if (platform === 'twitch') {
-      if (isTwitchUserId(platformUserId)) {
-        sevenTVPlatformId = platformUserId
-      } else if (isTwitchUserId(channelId)) {
-        sevenTVPlatformId = channelId
-      } else {
-        const normalizedLogin = normalizeTwitchLogin(channelId)
-        if (!normalizedLogin) {
-          throw new Error(`Invalid Twitch channel login: ${channelId}`)
-        }
-
-        const resolvedUsers = await resolveTwitchUserIdsByLogin([normalizedLogin])
-        const resolvedPlatformId = resolvedUsers.get(normalizedLogin)
-        if (!resolvedPlatformId) {
-          throw new Error(`Twitch user not found for login: ${normalizedLogin}`)
-        }
-
-        sevenTVPlatformId = resolvedPlatformId
+      const twitchIdentifier = isTwitchUserId(platformUserId) ? platformUserId : channelId
+      const resolvedPlatformId = await resolveTwitchUserId(twitchIdentifier)
+      if (!resolvedPlatformId) {
+        throw new Error(`Twitch user not found for identifier: ${twitchIdentifier}`)
       }
+
+      sevenTVPlatformId = resolvedPlatformId
+      log.info('Resolved Twitch user for 7TV lookup', {
+        channelId,
+        channelKey,
+        platformUserId,
+        sevenTVPlatformId,
+      })
     }
 
     const result = await getUserByConnection(
@@ -225,7 +216,7 @@ export class SevenTVSubscriptionManager {
 
     const user = result.users?.userByConnection
     if (!user) {
-      throw new Error('User not found on 7TV')
+      throw new Error(`User not found on 7TV for ${platform}:${sevenTVPlatformId}`)
     }
 
     const emoteSet = user.style?.activeEmoteSet

--- a/packages/backend/tests/twitch-users.test.ts
+++ b/packages/backend/tests/twitch-users.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it, mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   isTwitchUserId,
   normalizeTwitchLogin,
+  resolveTwitchUserId,
   resolveTwitchUserIdsByLogin,
 } from '../src/api/twitch-users.ts'
 
 describe('twitch-users helpers', () => {
+  beforeEach(() => {
+    global.fetch = fetch
+  })
+
   it('normalizes Twitch logins', () => {
     expect(normalizeTwitchLogin('@Satont ')).toBe('satont')
     expect(normalizeTwitchLogin('https://www.twitch.tv/Satont/')).toBe('satont')
@@ -21,6 +26,17 @@ describe('twitch-users helpers', () => {
     expect(isTwitchUserId('12345')).toBe(true)
     expect(isTwitchUserId('abc123')).toBe(false)
     expect(isTwitchUserId(undefined)).toBe(false)
+  })
+
+  it('returns numeric Twitch ids without fetching', async () => {
+    let called = false
+    global.fetch = mock(async () => {
+      called = true
+      return Response.json({})
+    }) as unknown as typeof global.fetch
+
+    await expect(resolveTwitchUserId('12345')).resolves.toBe('12345')
+    expect(called).toBe(false)
   })
 
   it('resolves only valid normalized logins', async () => {
@@ -48,5 +64,49 @@ describe('twitch-users helpers', () => {
     expect(calls[0]).not.toContain('bad%20slug')
     expect(result.get('satont')).toBe('100')
     expect(result.get('other_user')).toBe('200')
+  })
+
+  it('retries app-token-backed Helix user lookup after a 401', async () => {
+    const calls: string[] = []
+    let tokenRequestCount = 0
+
+    global.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      calls.push(url)
+
+      if (url === 'https://id.twitch.tv/oauth2/token') {
+        tokenRequestCount += 1
+
+        return Response.json({
+          access_token: tokenRequestCount === 1 ? 'stale-token' : 'fresh-token',
+          expires_in: 3600,
+        })
+      }
+
+      if (url.startsWith('https://api.twitch.tv/helix/users?')) {
+        const authHeader = new Headers(init?.headers).get('Authorization')
+
+        if (authHeader === 'Bearer stale-token') {
+          return new Response('Unauthorized', { status: 401 })
+        }
+
+        return Response.json({
+          data: [{ id: '100', login: 'satont' }],
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as unknown as typeof global.fetch
+
+    const result = await resolveTwitchUserIdsByLogin(['satont'])
+
+    expect(result.get('satont')).toBe('100')
+    expect(tokenRequestCount).toBe(2)
+    expect(calls).toEqual([
+      'https://id.twitch.tv/oauth2/token',
+      'https://api.twitch.tv/helix/users?login=satont',
+      'https://id.twitch.tv/oauth2/token',
+      'https://api.twitch.tv/helix/users?login=satont',
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- add a shared Twitch Helix app-token retry path that invalidates stale client-credentials tokens after a 401 and reuse it across stream status, badges, category search, and bulk channel status lookups
- normalize Twitch identifiers before 7TV lookup so backend subscriptions resolve logins to numeric Twitch user ids and report clearer 7TV lookup failures
- extend backend Twitch helper tests to cover numeric id passthrough and stale-token retry behavior

## Verification
- bun run fix
- bun run typecheck
- bun test tests/