### PR TITLE
feat: add backend-driven user card metadata

### DIFF
--- a/packages/backend/src/api/twitch-users.ts
+++ b/packages/backend/src/api/twitch-users.ts
@@ -6,6 +6,11 @@ export interface HelixUser {
   login: string
 }
 
+export interface HelixUserProfile extends HelixUser {
+  display_name?: string
+  profile_image_url?: string
+}
+
 const TWITCH_LOGIN_RE = /^[a-z0-9_]{4,25}$/
 const TWITCH_USER_ID_RE = /^\d+$/
 
@@ -82,4 +87,31 @@ export async function resolveTwitchUserIdsByLogin(
   }
 
   return loginToId
+}
+
+export async function fetchTwitchUserById(
+  userId: string,
+  userAccessToken?: string,
+): Promise<HelixUserProfile | null> {
+  if (!isTwitchUserId(userId)) {
+    return null
+  }
+
+  const url = `https://api.twitch.tv/helix/users?id=${encodeURIComponent(userId)}`
+  const response = userAccessToken
+    ? await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${userAccessToken}`,
+          'Client-Id': config.TWITCH_CLIENT_ID,
+        },
+      })
+    : await fetchTwitchHelixWithAppToken(url)
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Twitch /helix/users by id failed: ${response.status} ${body}`)
+  }
+
+  const payload = (await response.json()) as { data: HelixUserProfile[] }
+  return payload.data[0] ?? null
 }

--- a/packages/backend/src/api/user-card-metadata.ts
+++ b/packages/backend/src/api/user-card-metadata.ts
@@ -1,0 +1,305 @@
+import { config } from '../config.ts'
+import { AccountStore, type PlatformAccount } from '../db/index.ts'
+import { fetchTwitchHelixWithAppToken } from './stream-status.ts'
+import { resolveTwitchUserId } from './twitch-users.ts'
+import type {
+  UserCardAccountAgeField,
+  UserCardFollowAgeField,
+  UserCardMetadataResponse,
+  UserCardSubAgeField,
+  UserCardSubscriptionDurationField,
+} from '@twirchat/shared'
+
+interface TwitchUserResponse {
+  data: Array<{
+    id: string
+    created_at: string
+  }>
+}
+
+interface TwitchFollowerResponse {
+  data: Array<{
+    followed_at: string
+  }>
+}
+
+interface TwitchSubscriptionResponse {
+  data: Array<{
+    tier?: string
+    is_gift?: boolean
+    gifter_name?: string
+  }>
+}
+
+function unavailableAccountAge(
+  status: UserCardAccountAgeField['status'],
+  message: string,
+): UserCardAccountAgeField {
+  return { status, createdAt: null, message }
+}
+
+function availableAccountAge(createdAt: string): UserCardAccountAgeField {
+  return { status: 'available', createdAt }
+}
+
+function unavailableFollowAge(
+  status: UserCardFollowAgeField['status'],
+  message: string,
+): UserCardFollowAgeField {
+  return { status, followedAt: null, message }
+}
+
+function availableFollowAge(followedAt: string): UserCardFollowAgeField {
+  return { status: 'available', followedAt }
+}
+
+function unavailableSubscriptionDuration(
+  status: UserCardSubscriptionDurationField['status'],
+  message: string,
+): UserCardSubscriptionDurationField {
+  return {
+    status,
+    currentlySubscribed: null,
+    message,
+  }
+}
+
+function availableSubscriptionDuration(
+  currentlySubscribed: boolean,
+  extras: Omit<UserCardSubscriptionDurationField, 'status' | 'currentlySubscribed'> = {},
+): UserCardSubscriptionDurationField {
+  return {
+    status: 'available',
+    currentlySubscribed,
+    ...extras,
+  }
+}
+
+function unavailableSubAge(
+  status: UserCardSubAgeField['status'],
+  message: string,
+): UserCardSubAgeField {
+  return { status, months: null, message }
+}
+
+async function resolveTwitchBroadcasterId(
+  channelId: string | undefined,
+  account: PlatformAccount | null,
+): Promise<string | null> {
+  if (!channelId || !account) {
+    return null
+  }
+
+  return resolveTwitchUserId(channelId, account.accessToken)
+}
+
+async function fetchTwitchAccountAge(platformUserId: string): Promise<UserCardAccountAgeField> {
+  const response = await fetchTwitchHelixWithAppToken(
+    `https://api.twitch.tv/helix/users?id=${encodeURIComponent(platformUserId)}`,
+  )
+
+  if (!response.ok) {
+    return unavailableAccountAge('unavailable', `Twitch user lookup failed (${response.status}).`)
+  }
+
+  const body = (await response.json()) as TwitchUserResponse
+  const user = body.data[0]
+
+  if (!user?.created_at) {
+    return unavailableAccountAge('unavailable', 'Twitch did not return an account creation date.')
+  }
+
+  return availableAccountAge(user.created_at)
+}
+
+async function fetchTwitchFollowAge(
+  targetUserId: string,
+  channelId: string | undefined,
+  account: PlatformAccount | null,
+): Promise<UserCardFollowAgeField> {
+  if (!account) {
+    return unavailableFollowAge(
+      'unavailable',
+      'Follow age requires an authenticated Twitch account.',
+    )
+  }
+
+  if (!account.scopes.includes('moderator:read:followers')) {
+    return unavailableFollowAge(
+      'missing_permission',
+      'Follow age requires Twitch broadcaster auth with moderator:read:followers.',
+    )
+  }
+
+  const broadcasterId = await resolveTwitchBroadcasterId(channelId, account)
+  if (!broadcasterId) {
+    return unavailableFollowAge(
+      'unavailable',
+      'Could not resolve the Twitch channel for this message.',
+    )
+  }
+
+  const response = await fetch(
+    `https://api.twitch.tv/helix/channels/followers?broadcaster_id=${encodeURIComponent(
+      broadcasterId,
+    )}&user_id=${encodeURIComponent(targetUserId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${account.accessToken}`,
+        'Client-Id': config.TWITCH_CLIENT_ID,
+      },
+    },
+  )
+
+  if (response.status === 401 || response.status === 403) {
+    return unavailableFollowAge(
+      'missing_permission',
+      'Twitch denied follow lookup for this broadcaster token.',
+    )
+  }
+
+  if (!response.ok) {
+    return unavailableFollowAge('unavailable', `Twitch follow lookup failed (${response.status}).`)
+  }
+
+  const body = (await response.json()) as TwitchFollowerResponse
+  const follow = body.data[0]
+
+  if (!follow?.followed_at) {
+    return unavailableFollowAge('unavailable', 'This user is not currently following this channel.')
+  }
+
+  return availableFollowAge(follow.followed_at)
+}
+
+async function fetchTwitchSubscriptionDuration(
+  targetUserId: string,
+  channelId: string | undefined,
+  account: PlatformAccount | null,
+): Promise<UserCardSubscriptionDurationField> {
+  if (!account) {
+    return unavailableSubscriptionDuration(
+      'unavailable',
+      'Subscription status requires an authenticated Twitch account.',
+    )
+  }
+
+  if (!account.scopes.includes('channel:read:subscriptions')) {
+    return unavailableSubscriptionDuration(
+      'missing_permission',
+      'Subscription status requires Twitch broadcaster auth with channel:read:subscriptions.',
+    )
+  }
+
+  const broadcasterId = await resolveTwitchBroadcasterId(channelId, account)
+  if (!broadcasterId) {
+    return unavailableSubscriptionDuration(
+      'unavailable',
+      'Could not resolve the Twitch channel for this message.',
+    )
+  }
+
+  if (broadcasterId !== account.platformUserId) {
+    return unavailableSubscriptionDuration(
+      'unavailable',
+      'Subscription status is only available for your authenticated Twitch channel.',
+    )
+  }
+
+  const response = await fetch(
+    `https://api.twitch.tv/helix/subscriptions?broadcaster_id=${encodeURIComponent(
+      broadcasterId,
+    )}&user_id=${encodeURIComponent(targetUserId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${account.accessToken}`,
+        'Client-Id': config.TWITCH_CLIENT_ID,
+      },
+    },
+  )
+
+  if (response.status === 401 || response.status === 403) {
+    return unavailableSubscriptionDuration(
+      'missing_permission',
+      'Twitch denied subscription lookup for this broadcaster token.',
+    )
+  }
+
+  if (!response.ok) {
+    return unavailableSubscriptionDuration(
+      'unavailable',
+      `Twitch subscription lookup failed (${response.status}).`,
+    )
+  }
+
+  const body = (await response.json()) as TwitchSubscriptionResponse
+  const subscription = body.data[0]
+
+  if (!subscription) {
+    return availableSubscriptionDuration(false, {
+      message: 'Not currently subscribed to this channel.',
+    })
+  }
+
+  return availableSubscriptionDuration(true, {
+    tier: subscription.tier,
+    isGift: subscription.is_gift,
+    gifterDisplayName: subscription.gifter_name,
+    message: 'Current subscription status is available, but on-demand tenure is not.',
+  })
+}
+
+function buildKickMetadata(platformUserId: string): UserCardMetadataResponse {
+  return {
+    platform: 'kick',
+    platformUserId,
+    fetchedAt: Date.now(),
+    accountAge: unavailableAccountAge(
+      'unsupported',
+      'Kick does not expose account age through the available API.',
+    ),
+    followAge: unavailableFollowAge(
+      'unsupported',
+      'Kick does not expose follow age through the available API.',
+    ),
+    subscriptionDuration: unavailableSubscriptionDuration(
+      'unsupported',
+      'Kick does not expose on-demand subscription status through the available API.',
+    ),
+    subAge: unavailableSubAge(
+      'unsupported',
+      'Kick does not expose on-demand sub age through the available API.',
+    ),
+  }
+}
+
+export async function fetchUserCardMetadata(
+  clientSecret: string,
+  platform: 'twitch' | 'kick',
+  platformUserId: string,
+  channelId?: string,
+): Promise<UserCardMetadataResponse> {
+  if (platform === 'kick') {
+    return buildKickMetadata(platformUserId)
+  }
+
+  const account = await AccountStore.findByClientAndPlatform(clientSecret, 'twitch')
+  const [accountAge, followAge, subscriptionDuration] = await Promise.all([
+    fetchTwitchAccountAge(platformUserId),
+    fetchTwitchFollowAge(platformUserId, channelId, account),
+    fetchTwitchSubscriptionDuration(platformUserId, channelId, account),
+  ])
+
+  return {
+    platform: 'twitch',
+    platformUserId,
+    fetchedAt: Date.now(),
+    accountAge,
+    followAge,
+    subscriptionDuration,
+    subAge: unavailableSubAge(
+      'unsupported',
+      'Twitch does not expose on-demand sub age through the available broadcaster API.',
+    ),
+  }
+}

--- a/packages/backend/src/api/user-card-metadata.ts
+++ b/packages/backend/src/api/user-card-metadata.ts
@@ -1,14 +1,20 @@
 import { config } from '../config.ts'
-import { AccountStore, type PlatformAccount } from '../db/index.ts'
 import { fetchTwitchHelixWithAppToken } from './stream-status.ts'
 import { resolveTwitchUserId } from './twitch-users.ts'
 import type {
   UserCardAccountAgeField,
+  UserCardMetadataBackendRequest,
   UserCardFollowAgeField,
   UserCardMetadataResponse,
   UserCardSubAgeField,
   UserCardSubscriptionDurationField,
 } from '@twirchat/shared'
+
+interface TwitchAuthContext {
+  accessToken: string
+  platformUserId: string
+  scopes: string[]
+}
 
 interface TwitchUserResponse {
   data: Array<{
@@ -29,6 +35,14 @@ interface TwitchSubscriptionResponse {
     is_gift?: boolean
     gifter_name?: string
   }>
+}
+
+interface KickChannelUserResponse {
+  username: string
+  slug: string
+  profile_pic?: string | null
+  following_since?: string | null
+  subscribed_for?: number | null
 }
 
 function unavailableAccountAge(
@@ -82,15 +96,19 @@ function unavailableSubAge(
   return { status, months: null, message }
 }
 
+function availableSubAge(months: number, message?: string): UserCardSubAgeField {
+  return { status: 'available', months, message }
+}
+
 async function resolveTwitchBroadcasterId(
   channelId: string | undefined,
-  account: PlatformAccount | null,
+  auth: TwitchAuthContext | undefined,
 ): Promise<string | null> {
-  if (!channelId || !account) {
+  if (!channelId || !auth) {
     return null
   }
 
-  return resolveTwitchUserId(channelId, account.accessToken)
+  return resolveTwitchUserId(channelId, auth.accessToken)
 }
 
 async function fetchTwitchAccountAge(platformUserId: string): Promise<UserCardAccountAgeField> {
@@ -115,23 +133,23 @@ async function fetchTwitchAccountAge(platformUserId: string): Promise<UserCardAc
 async function fetchTwitchFollowAge(
   targetUserId: string,
   channelId: string | undefined,
-  account: PlatformAccount | null,
+  auth: TwitchAuthContext | undefined,
 ): Promise<UserCardFollowAgeField> {
-  if (!account) {
+  if (!auth) {
     return unavailableFollowAge(
       'unavailable',
       'Follow age requires an authenticated Twitch account.',
     )
   }
 
-  if (!account.scopes.includes('moderator:read:followers')) {
+  if (!auth.scopes.includes('moderator:read:followers')) {
     return unavailableFollowAge(
       'missing_permission',
       'Follow age requires Twitch broadcaster auth with moderator:read:followers.',
     )
   }
 
-  const broadcasterId = await resolveTwitchBroadcasterId(channelId, account)
+  const broadcasterId = await resolveTwitchBroadcasterId(channelId, auth)
   if (!broadcasterId) {
     return unavailableFollowAge(
       'unavailable',
@@ -145,7 +163,7 @@ async function fetchTwitchFollowAge(
     )}&user_id=${encodeURIComponent(targetUserId)}`,
     {
       headers: {
-        Authorization: `Bearer ${account.accessToken}`,
+        Authorization: `Bearer ${auth.accessToken}`,
         'Client-Id': config.TWITCH_CLIENT_ID,
       },
     },
@@ -175,23 +193,23 @@ async function fetchTwitchFollowAge(
 async function fetchTwitchSubscriptionDuration(
   targetUserId: string,
   channelId: string | undefined,
-  account: PlatformAccount | null,
+  auth: TwitchAuthContext | undefined,
 ): Promise<UserCardSubscriptionDurationField> {
-  if (!account) {
+  if (!auth) {
     return unavailableSubscriptionDuration(
       'unavailable',
       'Subscription status requires an authenticated Twitch account.',
     )
   }
 
-  if (!account.scopes.includes('channel:read:subscriptions')) {
+  if (!auth.scopes.includes('channel:read:subscriptions')) {
     return unavailableSubscriptionDuration(
       'missing_permission',
       'Subscription status requires Twitch broadcaster auth with channel:read:subscriptions.',
     )
   }
 
-  const broadcasterId = await resolveTwitchBroadcasterId(channelId, account)
+  const broadcasterId = await resolveTwitchBroadcasterId(channelId, auth)
   if (!broadcasterId) {
     return unavailableSubscriptionDuration(
       'unavailable',
@@ -199,7 +217,7 @@ async function fetchTwitchSubscriptionDuration(
     )
   }
 
-  if (broadcasterId !== account.platformUserId) {
+  if (broadcasterId !== auth.platformUserId) {
     return unavailableSubscriptionDuration(
       'unavailable',
       'Subscription status is only available for your authenticated Twitch channel.',
@@ -212,7 +230,7 @@ async function fetchTwitchSubscriptionDuration(
     )}&user_id=${encodeURIComponent(targetUserId)}`,
     {
       headers: {
-        Authorization: `Bearer ${account.accessToken}`,
+        Authorization: `Bearer ${auth.accessToken}`,
         'Client-Id': config.TWITCH_CLIENT_ID,
       },
     },
@@ -249,7 +267,67 @@ async function fetchTwitchSubscriptionDuration(
   })
 }
 
-function buildKickMetadata(platformUserId: string): UserCardMetadataResponse {
+async function fetchKickUserMetadata(
+  platformUserId: string,
+  username: string | undefined,
+  channelSlug: string | undefined,
+): Promise<UserCardMetadataResponse> {
+  if (!username || !channelSlug) {
+    return {
+      platform: 'kick',
+      platformUserId,
+      fetchedAt: Date.now(),
+      accountAge: unavailableAccountAge(
+        'unsupported',
+        'Kick does not expose account age through the available API.',
+      ),
+      followAge: unavailableFollowAge(
+        'unavailable',
+        'Kick follow/subscription metadata needs the channel slug and chatter username.',
+      ),
+      subscriptionDuration: unavailableSubscriptionDuration(
+        'unavailable',
+        'Kick follow/subscription metadata needs the channel slug and chatter username.',
+      ),
+      subAge: unavailableSubAge(
+        'unavailable',
+        'Kick follow/subscription metadata needs the channel slug and chatter username.',
+      ),
+    }
+  }
+
+  const response = await fetch(
+    `https://kick.com/api/v2/channels/${encodeURIComponent(channelSlug)}/users/${encodeURIComponent(username)}`,
+  )
+
+  if (!response.ok) {
+    return {
+      platform: 'kick',
+      platformUserId,
+      fetchedAt: Date.now(),
+      accountAge: unavailableAccountAge(
+        'unsupported',
+        'Kick does not expose account age through the available API.',
+      ),
+      followAge: unavailableFollowAge(
+        'unavailable',
+        `Kick user metadata lookup failed (${response.status}).`,
+      ),
+      subscriptionDuration: unavailableSubscriptionDuration(
+        'unavailable',
+        `Kick user metadata lookup failed (${response.status}).`,
+      ),
+      subAge: unavailableSubAge(
+        'unavailable',
+        `Kick user metadata lookup failed (${response.status}).`,
+      ),
+    }
+  }
+
+  const body = (await response.json()) as KickChannelUserResponse
+  const subscribedFor = body.subscribed_for ?? 0
+  const isSubscribed = subscribedFor > 0
+
   return {
     platform: 'kick',
     platformUserId,
@@ -258,36 +336,38 @@ function buildKickMetadata(platformUserId: string): UserCardMetadataResponse {
       'unsupported',
       'Kick does not expose account age through the available API.',
     ),
-    followAge: unavailableFollowAge(
-      'unsupported',
-      'Kick does not expose follow age through the available API.',
-    ),
-    subscriptionDuration: unavailableSubscriptionDuration(
-      'unsupported',
-      'Kick does not expose on-demand subscription status through the available API.',
-    ),
-    subAge: unavailableSubAge(
-      'unsupported',
-      'Kick does not expose on-demand sub age through the available API.',
-    ),
+    followAge: body.following_since
+      ? availableFollowAge(body.following_since)
+      : unavailableFollowAge('unavailable', 'This user is not currently following this channel.'),
+    subscriptionDuration: isSubscribed
+      ? availableSubscriptionDuration(true, {
+          message: `Subscribed for ${subscribedFor} month${subscribedFor === 1 ? '' : 's'}.`,
+        })
+      : availableSubscriptionDuration(false, {
+          message: 'Not currently subscribed to this channel.',
+        }),
+    subAge: isSubscribed
+      ? availableSubAge(
+          subscribedFor,
+          `Subscribed for ${subscribedFor} month${subscribedFor === 1 ? '' : 's'}.`,
+        )
+      : unavailableSubAge('unavailable', 'This user is not currently subscribed to this channel.'),
   }
 }
 
 export async function fetchUserCardMetadata(
-  clientSecret: string,
-  platform: 'twitch' | 'kick',
-  platformUserId: string,
-  channelId?: string,
+  params: UserCardMetadataBackendRequest,
 ): Promise<UserCardMetadataResponse> {
+  const { platform, platformUserId, channelId, channelSlug, username, twitchAuth } = params
+
   if (platform === 'kick') {
-    return buildKickMetadata(platformUserId)
+    return fetchKickUserMetadata(platformUserId, username, channelSlug)
   }
 
-  const account = await AccountStore.findByClientAndPlatform(clientSecret, 'twitch')
   const [accountAge, followAge, subscriptionDuration] = await Promise.all([
     fetchTwitchAccountAge(platformUserId),
-    fetchTwitchFollowAge(platformUserId, channelId, account),
-    fetchTwitchSubscriptionDuration(platformUserId, channelId, account),
+    fetchTwitchFollowAge(platformUserId, channelId, twitchAuth),
+    fetchTwitchSubscriptionDuration(platformUserId, channelId, twitchAuth),
   ])
 
   return {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -4,6 +4,7 @@ import { handleWsClose, handleWsMessage, handleWsOpen } from './ws/handlers.ts'
 import { authRoutes } from './routes/auth.ts'
 import { accountRoutes } from './routes/accounts.ts'
 import { streamRoutes } from './routes/stream.ts'
+import { userCardRoutes } from './routes/user-card.ts'
 import { webhookRoutes } from './routes/webhooks.ts'
 import { youtubeRoutes } from './routes/youtube.ts'
 import { json } from './routes/utils.ts'
@@ -58,6 +59,7 @@ const server = Bun.serve<WsData>({
     ...authRoutes,
     ...accountRoutes,
     ...streamRoutes,
+    ...userCardRoutes,
     ...webhookRoutes,
     ...youtubeRoutes,
     '/health': () => json({ ok: true }),

--- a/packages/backend/src/routes/stream.ts
+++ b/packages/backend/src/routes/stream.ts
@@ -2,6 +2,7 @@ import { handleStreamStatus } from '../api/stream-status.ts'
 import { handleUpdateStream } from '../api/update-stream.ts'
 import { handleSearchCategories } from '../api/search-categories.ts'
 import { handleTwitchBadges } from '../api/twitch-badges.ts'
+import { fetchTwitchUserById } from '../api/twitch-users.ts'
 import { handleChannelsStatus } from '../api/channels-status.ts'
 import { handleKickChatroom } from '../api/kick-chatroom.ts'
 import { json, requireClient } from './utils.ts'
@@ -71,6 +72,23 @@ export const streamRoutes = {
         return json(result)
       } catch (err) {
         log.error('twitch/badges failed', { err: String(err) })
+        return json({ error: String(err) }, 500)
+      }
+    },
+  },
+  '/api/twitch/user': {
+    async GET(req: Request) {
+      try {
+        const url = new URL(req.url)
+        const userId = url.searchParams.get('userId')
+        if (!userId) {
+          return json({ error: 'userId is required' }, 400)
+        }
+
+        const user = await fetchTwitchUserById(userId)
+        return json({ user })
+      } catch (err) {
+        log.error('twitch/user failed', { err: String(err) })
         return json({ error: String(err) }, 500)
       }
     },

--- a/packages/backend/src/routes/user-card.ts
+++ b/packages/backend/src/routes/user-card.ts
@@ -1,0 +1,32 @@
+import { fetchUserCardMetadata } from '../api/user-card-metadata.ts'
+import { json, requireClient } from './utils.ts'
+import { logger } from '@twirchat/shared/logger'
+
+const log = logger('user-card-route')
+
+export const userCardRoutes = {
+  '/api/user-card-metadata': {
+    async GET(req: Request) {
+      const auth = await requireClient(req)
+      if (auth instanceof Response) return auth
+
+      try {
+        const url = new URL(req.url)
+        const platform = url.searchParams.get('platform')
+        const platformUserId = url.searchParams.get('platformUserId')
+        const channelId = url.searchParams.get('channelId') ?? undefined
+
+        if ((platform !== 'twitch' && platform !== 'kick') || !platformUserId) {
+          return json({ error: 'platform=twitch|kick and platformUserId are required' }, 400)
+        }
+
+        return json(
+          await fetchUserCardMetadata(auth.clientSecret, platform, platformUserId, channelId),
+        )
+      } catch (err) {
+        log.error('user-card-metadata failed', { err: String(err) })
+        return json({ error: String(err) }, 500)
+      }
+    },
+  },
+} as const

--- a/packages/backend/src/routes/user-card.ts
+++ b/packages/backend/src/routes/user-card.ts
@@ -6,23 +6,19 @@ const log = logger('user-card-route')
 
 export const userCardRoutes = {
   '/api/user-card-metadata': {
-    async GET(req: Request) {
+    async POST(req: Request) {
       const auth = await requireClient(req)
       if (auth instanceof Response) return auth
 
       try {
-        const url = new URL(req.url)
-        const platform = url.searchParams.get('platform')
-        const platformUserId = url.searchParams.get('platformUserId')
-        const channelId = url.searchParams.get('channelId') ?? undefined
+        const body = (await req.json()) as import('@twirchat/shared').UserCardMetadataBackendRequest
+        const { platform, platformUserId } = body
 
         if ((platform !== 'twitch' && platform !== 'kick') || !platformUserId) {
           return json({ error: 'platform=twitch|kick and platformUserId are required' }, 400)
         }
 
-        return json(
-          await fetchUserCardMetadata(auth.clientSecret, platform, platformUserId, channelId),
-        )
+        return json(await fetchUserCardMetadata(body))
       } catch (err) {
         log.error('user-card-metadata failed', { err: String(err) })
         return json({ error: String(err) }, 500)

--- a/packages/backend/tests/twitch-users.test.ts
+++ b/packages/backend/tests/twitch-users.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
+  fetchTwitchUserById,
   isTwitchUserId,
   normalizeTwitchLogin,
   resolveTwitchUserId,
@@ -108,5 +109,39 @@ describe('twitch-users helpers', () => {
       'https://id.twitch.tv/oauth2/token',
       'https://api.twitch.tv/helix/users?login=satont',
     ])
+  })
+
+  it('fetches Twitch user profile by id', async () => {
+    global.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input)
+
+      if (url === 'https://id.twitch.tv/oauth2/token') {
+        return Response.json({ access_token: 'app-token', expires_in: 3600 })
+      }
+
+      if (url === 'https://api.twitch.tv/helix/users?id=12345') {
+        return Response.json({
+          data: [
+            {
+              id: '12345',
+              login: 'satont',
+              display_name: 'Satont',
+              profile_image_url: 'https://example.com/avatar.png',
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as unknown as typeof global.fetch
+
+    const profile = await fetchTwitchUserById('12345')
+
+    expect(profile).toEqual({
+      id: '12345',
+      login: 'satont',
+      display_name: 'Satont',
+      profile_image_url: 'https://example.com/avatar.png',
+    })
   })
 })

--- a/packages/backend/tests/user-card-metadata.test.ts
+++ b/packages/backend/tests/user-card-metadata.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { fetchUserCardMetadata } from '../src/api/user-card-metadata.ts'
+import { AccountStore } from '../src/db/store.ts'
+
+describe('user card metadata', () => {
+  beforeEach(() => {
+    global.fetch = fetch
+  })
+
+  it('returns unsupported Kick metadata', async () => {
+    const metadata = await fetchUserCardMetadata('client-1', 'kick', 'user-1', '123')
+
+    expect(metadata.platform).toBe('kick')
+    expect(metadata.accountAge.status).toBe('unsupported')
+    expect(metadata.followAge.status).toBe('unsupported')
+    expect(metadata.subscriptionDuration.status).toBe('unsupported')
+    expect(metadata.subAge.status).toBe('unsupported')
+  })
+
+  it('maps Twitch account age, follow age, and current subscription state', async () => {
+    const originalFindByClientAndPlatform = AccountStore.findByClientAndPlatform
+    AccountStore.findByClientAndPlatform = async () => ({
+      id: 'twitch:broadcaster-id',
+      clientSecret: 'client-1',
+      platform: 'twitch',
+      platformUserId: 'broadcaster-id',
+      username: 'broadcaster',
+      displayName: 'Broadcaster',
+      accessToken: 'token-1',
+      scopes: ['channel:read:subscriptions', 'moderator:read:followers'],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    global.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input)
+
+      if (url === 'https://id.twitch.tv/oauth2/token') {
+        return Response.json({
+          access_token: 'app-token',
+          expires_in: 3600,
+        })
+      }
+
+      if (url.includes('/helix/users?id=target-user')) {
+        return Response.json({
+          data: [{ id: 'target-user', created_at: '2020-01-02T03:04:05Z' }],
+        })
+      }
+
+      if (url.includes('/helix/users?login=broadcaster')) {
+        return Response.json({
+          data: [{ id: 'broadcaster-id', login: 'broadcaster' }],
+        })
+      }
+
+      if (url.includes('/helix/channels/followers?')) {
+        return Response.json({
+          data: [{ followed_at: '2021-02-03T04:05:06Z' }],
+        })
+      }
+
+      if (url.includes('/helix/subscriptions?')) {
+        return Response.json({
+          data: [{ tier: '1000', is_gift: true, gifter_name: 'GiftUser' }],
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as unknown as typeof global.fetch
+
+    try {
+      const metadata = await fetchUserCardMetadata(
+        'client-1',
+        'twitch',
+        'target-user',
+        'broadcaster',
+      )
+
+      expect(metadata.accountAge.status).toBe('available')
+      expect(metadata.accountAge.createdAt).toBe('2020-01-02T03:04:05Z')
+      expect(metadata.followAge.status).toBe('available')
+      expect(metadata.followAge.followedAt).toBe('2021-02-03T04:05:06Z')
+      expect(metadata.subscriptionDuration.status).toBe('available')
+      expect(metadata.subscriptionDuration.currentlySubscribed).toBe(true)
+      expect(metadata.subscriptionDuration.tier).toBe('1000')
+      expect(metadata.subAge.status).toBe('unsupported')
+    } finally {
+      AccountStore.findByClientAndPlatform = originalFindByClientAndPlatform
+    }
+  })
+})

--- a/packages/backend/tests/user-card-metadata.test.ts
+++ b/packages/backend/tests/user-card-metadata.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import { fetchUserCardMetadata } from '../src/api/user-card-metadata.ts'
-import { AccountStore } from '../src/db/store.ts'
 
 describe('user card metadata', () => {
   beforeEach(() => {
@@ -9,30 +8,20 @@ describe('user card metadata', () => {
   })
 
   it('returns unsupported Kick metadata', async () => {
-    const metadata = await fetchUserCardMetadata('client-1', 'kick', 'user-1', '123')
+    const metadata = await fetchUserCardMetadata({
+      platform: 'kick',
+      platformUserId: 'user-1',
+      channelId: '123',
+    })
 
     expect(metadata.platform).toBe('kick')
     expect(metadata.accountAge.status).toBe('unsupported')
-    expect(metadata.followAge.status).toBe('unsupported')
-    expect(metadata.subscriptionDuration.status).toBe('unsupported')
-    expect(metadata.subAge.status).toBe('unsupported')
+    expect(metadata.followAge.status).toBe('unavailable')
+    expect(metadata.subscriptionDuration.status).toBe('unavailable')
+    expect(metadata.subAge.status).toBe('unavailable')
   })
 
   it('maps Twitch account age, follow age, and current subscription state', async () => {
-    const originalFindByClientAndPlatform = AccountStore.findByClientAndPlatform
-    AccountStore.findByClientAndPlatform = async () => ({
-      id: 'twitch:broadcaster-id',
-      clientSecret: 'client-1',
-      platform: 'twitch',
-      platformUserId: 'broadcaster-id',
-      username: 'broadcaster',
-      displayName: 'Broadcaster',
-      accessToken: 'token-1',
-      scopes: ['channel:read:subscriptions', 'moderator:read:followers'],
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    })
-
     global.fetch = mock(async (input: string | URL | Request) => {
       const url = String(input)
 
@@ -70,24 +59,58 @@ describe('user card metadata', () => {
       throw new Error(`Unexpected fetch: ${url}`)
     }) as unknown as typeof global.fetch
 
-    try {
-      const metadata = await fetchUserCardMetadata(
-        'client-1',
-        'twitch',
-        'target-user',
-        'broadcaster',
-      )
+    const metadata = await fetchUserCardMetadata({
+      platform: 'twitch',
+      platformUserId: 'target-user',
+      channelId: 'broadcaster',
+      twitchAuth: {
+        accessToken: 'token-1',
+        platformUserId: 'broadcaster-id',
+        scopes: ['channel:read:subscriptions', 'moderator:read:followers'],
+      },
+    })
 
-      expect(metadata.accountAge.status).toBe('available')
-      expect(metadata.accountAge.createdAt).toBe('2020-01-02T03:04:05Z')
-      expect(metadata.followAge.status).toBe('available')
-      expect(metadata.followAge.followedAt).toBe('2021-02-03T04:05:06Z')
-      expect(metadata.subscriptionDuration.status).toBe('available')
-      expect(metadata.subscriptionDuration.currentlySubscribed).toBe(true)
-      expect(metadata.subscriptionDuration.tier).toBe('1000')
-      expect(metadata.subAge.status).toBe('unsupported')
-    } finally {
-      AccountStore.findByClientAndPlatform = originalFindByClientAndPlatform
-    }
+    expect(metadata.accountAge.status).toBe('available')
+    expect(metadata.accountAge.createdAt).toBe('2020-01-02T03:04:05Z')
+    expect(metadata.followAge.status).toBe('available')
+    expect(metadata.followAge.followedAt).toBe('2021-02-03T04:05:06Z')
+    expect(metadata.subscriptionDuration.status).toBe('available')
+    expect(metadata.subscriptionDuration.currentlySubscribed).toBe(true)
+    expect(metadata.subscriptionDuration.tier).toBe('1000')
+    expect(metadata.subAge.status).toBe('unsupported')
+  })
+
+  it('maps Kick follow and subscription data from unofficial channel user endpoint', async () => {
+    global.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input)
+
+      if (url === 'https://kick.com/api/v2/channels/satont/users/jopyle4ka') {
+        return Response.json({
+          id: 35676191,
+          username: 'jopyle4ka',
+          slug: 'jopyle4ka',
+          profile_pic: 'https://files.kick.com/example.webp',
+          following_since: '2024-06-11T18:39:20.000000Z',
+          subscribed_for: 3,
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as unknown as typeof global.fetch
+
+    const metadata = await fetchUserCardMetadata({
+      platform: 'kick',
+      platformUserId: '35676191',
+      username: 'jopyle4ka',
+      channelSlug: 'satont',
+    })
+
+    expect(metadata.accountAge.status).toBe('unsupported')
+    expect(metadata.followAge.status).toBe('available')
+    expect(metadata.followAge.followedAt).toBe('2024-06-11T18:39:20.000000Z')
+    expect(metadata.subscriptionDuration.status).toBe('available')
+    expect(metadata.subscriptionDuration.currentlySubscribed).toBe(true)
+    expect(metadata.subAge.status).toBe('available')
+    expect(metadata.subAge.months).toBe(3)
   })
 })

--- a/packages/desktop/src/auth/twitch.ts
+++ b/packages/desktop/src/auth/twitch.ts
@@ -169,6 +169,24 @@ export async function handleTwitchCallback(url: URL): Promise<{
     scopes: string[]
   }
 
+  const userInfoRes = await fetch(
+    `https://api.twitch.tv/helix/users?id=${encodeURIComponent(validateData.user_id)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${tokens.accessToken}`,
+        'Client-Id': validateData.client_id,
+      },
+    },
+  )
+
+  const userInfo = userInfoRes.ok
+    ? (
+        (await userInfoRes.json()) as {
+          data?: Array<{ display_name?: string; profile_image_url?: string | null }>
+        }
+      ).data?.[0]
+    : undefined
+
   const expiresAt = tokens.expiresIn ? Math.floor(Date.now() / 1000) + tokens.expiresIn : undefined
 
   AccountStore.upsert({
@@ -176,7 +194,8 @@ export async function handleTwitchCallback(url: URL): Promise<{
     platform: 'twitch',
     platformUserId: validateData.user_id,
     username: validateData.login,
-    displayName: validateData.login, // Twitch validate endpoint doesn't return display name; good enough for now
+    displayName: userInfo?.display_name ?? validateData.login,
+    avatarUrl: userInfo?.profile_image_url ?? undefined,
     accessToken: tokens.accessToken,
     refreshToken: tokens.refreshToken,
     expiresAt,

--- a/packages/desktop/src/bun/index.ts
+++ b/packages/desktop/src/bun/index.ts
@@ -502,17 +502,38 @@ const rpc = defineElectrobunRPC<TwirChatRPCSchema>('bun', {
         })
       },
 
-      getUserCardMetadata: async ({ platform, platformUserId, channelId }) => {
-        const query = new URLSearchParams({
+      getUserCardMetadata: async ({
+        platform,
+        platformUserId,
+        username,
+        channelId,
+        channelSlug,
+      }) => {
+        const body: import('@twirchat/shared').UserCardMetadataBackendRequest = {
           platform,
           platformUserId,
-        })
-
-        if (channelId) {
-          query.set('channelId', channelId)
+          username,
+          channelId,
+          channelSlug,
         }
 
-        const res = await backendFetch(`/api/user-card-metadata?${query.toString()}`)
+        const account = AccountStore.findByPlatform(platform)
+        if (platform === 'twitch' && account) {
+          const tokens = AccountStore.getTokens(account.id)
+          if (tokens?.accessToken) {
+            body.twitchAuth = {
+              accessToken: tokens.accessToken,
+              platformUserId: account.platformUserId,
+              scopes: account.scopes,
+            }
+          }
+        }
+
+        const res = await backendFetch('/api/user-card-metadata', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
         if (!res.ok) throw new Error(`user-card-metadata: ${res.status}`)
         return (await res.json()) as UserCardMetadataResponse
       },
@@ -886,66 +907,66 @@ if (channel === 'dev') {
 // every resize event, locking the minimum window size to the initial dimensions. We walk
 // the full GTK widget tree and reset size requests to (-1,-1) — "no minimum" — after a
 // short delay to let Electrobun finish its initial WebKit layout pass.
-if (process.platform === 'linux') {
-  void (async () => {
-    await Bun.sleep(300)
-    const { dlopen, FFIType, ptr: ffiPtr } = await import('bun:ffi')
-    try {
-      const gtk = dlopen('libgtk-3.so.0', {
-        gtk_widget_set_size_request: {
-          args: [FFIType.ptr, FFIType.i32, FFIType.i32],
-          returns: FFIType.void,
-        },
-        gtk_container_get_children: {
-          args: [FFIType.ptr],
-          returns: FFIType.ptr,
-        },
-        g_list_nth_data: {
-          args: [FFIType.ptr, FFIType.u32],
-          returns: FFIType.ptr,
-        },
-        g_list_length: {
-          args: [FFIType.ptr],
-          returns: FFIType.u32,
-        },
-        g_list_free: {
-          args: [FFIType.ptr],
-          returns: FFIType.void,
-        },
-      })
-
-      type Ptr = NonNullable<ReturnType<typeof ffiPtr>>
-
-      const clearSizeRequest = (widgetPtr: Ptr) => {
-        gtk.symbols.gtk_widget_set_size_request(widgetPtr, -1, -1)
-        try {
-          const children = gtk.symbols.gtk_container_get_children(widgetPtr)
-          if (!children) return
-          const len = gtk.symbols.g_list_length(children) as number
-          for (let i = 0; i < len; i++) {
-            const child = gtk.symbols.g_list_nth_data(children, i)
-            if (child) clearSizeRequest(child as Ptr)
-          }
-          gtk.symbols.g_list_free(children)
-        } catch {}
-      }
-
-      clearSizeRequest(win.ptr)
-
-      // Sync handler — no setTimeout/FFI callback indirection that crashes
-      // Bun's WebWorker (segfault at 0x8 in FFI_Callback_threadsafe_call).
-      win.on('resize', () => {
-        try {
-          if (win.ptr) clearSizeRequest(win.ptr)
-        } catch {
-          // Window destroyed — ignore.
-        }
-      })
-    } catch (err) {
-      log.warn('[linux] failed to clear gtk size constraints', { error: String(err) })
-    }
-  })()
-}
+// if (process.platform === 'linux') {
+//   void (async () => {
+//     await Bun.sleep(300)
+//     const { dlopen, FFIType, ptr: ffiPtr } = await import('bun:ffi')
+//     try {
+//       const gtk = dlopen('libgtk-3.so.0', {
+//         gtk_widget_set_size_request: {
+//           args: [FFIType.ptr, FFIType.i32, FFIType.i32],
+//           returns: FFIType.void,
+//         },
+//         gtk_container_get_children: {
+//           args: [FFIType.ptr],
+//           returns: FFIType.ptr,
+//         },
+//         g_list_nth_data: {
+//           args: [FFIType.ptr, FFIType.u32],
+//           returns: FFIType.ptr,
+//         },
+//         g_list_length: {
+//           args: [FFIType.ptr],
+//           returns: FFIType.u32,
+//         },
+//         g_list_free: {
+//           args: [FFIType.ptr],
+//           returns: FFIType.void,
+//         },
+//       })
+//
+//       type Ptr = NonNullable<ReturnType<typeof ffiPtr>>
+//
+//       const clearSizeRequest = (widgetPtr: Ptr) => {
+//         gtk.symbols.gtk_widget_set_size_request(widgetPtr, -1, -1)
+//         try {
+//           const children = gtk.symbols.gtk_container_get_children(widgetPtr)
+//           if (!children) return
+//           const len = gtk.symbols.g_list_length(children) as number
+//           for (let i = 0; i < len; i++) {
+//             const child = gtk.symbols.g_list_nth_data(children, i)
+//             if (child) clearSizeRequest(child as Ptr)
+//           }
+//           gtk.symbols.g_list_free(children)
+//         } catch {}
+//       }
+//
+//       clearSizeRequest(win.ptr)
+//
+//       // Sync handler — no setTimeout/FFI callback indirection that crashes
+//       // Bun's WebWorker (segfault at 0x8 in FFI_Callback_threadsafe_call).
+//       win.on('resize', () => {
+//         try {
+//           if (win.ptr) clearSizeRequest(win.ptr)
+//         } catch {
+//           // Window destroyed — ignore.
+//         }
+//       })
+//     } catch (err) {
+//       log.warn('[linux] failed to clear gtk size constraints', { error: String(err) })
+//     }
+//   })()
+// }
 
 // ============================================================
 // 3b. Auto-update setup

--- a/packages/desktop/src/bun/index.ts
+++ b/packages/desktop/src/bun/index.ts
@@ -86,10 +86,11 @@ process.title = 'TwirChat'
 import type { TwirChatRPCSchema, WebviewSender } from '../shared/rpc'
 import type {
   ChannelsStatusResponse,
+  SearchCategoriesResponse,
   StreamStatusResponse,
   UpdateStreamRequest,
   UpdateStreamResponse,
-  SearchCategoriesResponse,
+  UserCardMetadataResponse,
 } from '@twirchat/shared/protocol'
 import { startAuthServer, setAuthServerRpcSender, setOnAuthSuccessCallback } from '../auth'
 import { setRuntimeConfig, getRuntimeConfig, backendFetch } from '../runtime-config'
@@ -499,6 +500,21 @@ const rpc = defineElectrobunRPC<TwirChatRPCSchema>('bun', {
           limit,
           cursor,
         })
+      },
+
+      getUserCardMetadata: async ({ platform, platformUserId, channelId }) => {
+        const query = new URLSearchParams({
+          platform,
+          platformUserId,
+        })
+
+        if (channelId) {
+          query.set('channelId', channelId)
+        }
+
+        const res = await backendFetch(`/api/user-card-metadata?${query.toString()}`)
+        if (!res.ok) throw new Error(`user-card-metadata: ${res.status}`)
+        return (await res.json()) as UserCardMetadataResponse
       },
 
       getUsernameColor: ({ platform, username }) => {

--- a/packages/desktop/src/platforms/twitch/adapter.ts
+++ b/packages/desktop/src/platforms/twitch/adapter.ts
@@ -22,6 +22,7 @@ import { MessageStore } from '../../store/message-store'
 import { refreshTwitchToken } from '../../auth/twitch'
 import type { TwitchBadgesResponse } from '@twirchat/shared/types'
 import { logger } from '@twirchat/shared/logger'
+import { resolveTwitchAvatarUrl } from './avatar-cache'
 
 const log = logger('twitch')
 
@@ -29,6 +30,7 @@ interface LocalTwitchSentMessageParams {
   channelId: string
   text: string
   author: {
+    avatarUrl?: string
     displayName: string
     id: string
     username?: string
@@ -43,6 +45,7 @@ export function createLocalTwitchSentMessage(
 ): NormalizedChatMessage {
   return {
     author: {
+      avatarUrl: params.author.avatarUrl,
       badges: [],
       displayName: params.author.displayName,
       id: params.author.id,
@@ -299,7 +302,7 @@ export class TwitchAdapter extends BasePlatformAdapter {
 
     // Messages (also handles bits/cheers — msg.bits > 0 means a cheer)
     this.chatClient.onMessage((channel, user, text, msg) => {
-      this.handleChatMessage(msg)
+      void this.handleChatMessage(msg)
       if (msg.bits > 0) {
         this.handleCheerEvent(msg)
       }
@@ -307,7 +310,7 @@ export class TwitchAdapter extends BasePlatformAdapter {
 
     // Actions (/me)
     this.chatClient.onAction((channel, user, text, msg) => {
-      this.handleChatMessage(msg, true)
+      void this.handleChatMessage(msg, true)
     })
 
     // Subscriptions
@@ -448,6 +451,7 @@ export class TwitchAdapter extends BasePlatformAdapter {
         'message',
         createLocalTwitchSentMessage({
           author: {
+            avatarUrl: AccountStore.findByPlatform('twitch')?.avatarUrl,
             displayName,
             id: this.platformUserId ?? this.accountId ?? this.login ?? 'twitch-self',
             username: this.login ?? undefined,
@@ -491,7 +495,7 @@ export class TwitchAdapter extends BasePlatformAdapter {
     }
   }
 
-  private handleChatMessage(msg: ChatMessage, isAction = false): void {
+  private async handleChatMessage(msg: ChatMessage, isAction = false): Promise<void> {
     const channel = msg.target
     const { text } = msg
     const { tags } = msg
@@ -501,6 +505,7 @@ export class TwitchAdapter extends BasePlatformAdapter {
     const color = tags.get('color') || undefined
     const msgId = tags.get('id') ?? `${Date.now()}`
     const timestamp = msg.date
+    const avatarUrl = await resolveTwitchAvatarUrl({ authorId: userId })
 
     const replyParentMsgId = tags.get('reply-parent-msg-id')
     const replyParentMsgBody = tags.get('reply-parent-msg-body')
@@ -550,6 +555,7 @@ export class TwitchAdapter extends BasePlatformAdapter {
 
     const normalized: NormalizedChatMessage = {
       author: {
+        avatarUrl,
         badges,
         color,
         displayName,

--- a/packages/desktop/src/platforms/twitch/avatar-cache.ts
+++ b/packages/desktop/src/platforms/twitch/avatar-cache.ts
@@ -1,0 +1,106 @@
+import { getBackendUrl } from '../../runtime-config'
+
+interface TwitchAvatarCacheEntry {
+  avatarUrl?: string
+  expiresAt: number
+}
+
+export interface TwitchAvatarLookupInput {
+  authorId?: string | null
+}
+
+export interface TwitchAvatarResolverDependencies {
+  fetchFn?: typeof fetch
+  now?: () => number
+  timeoutMs?: number
+}
+
+export type TwitchAvatarResolver = (input: TwitchAvatarLookupInput) => Promise<string | undefined>
+
+export const TWITCH_AVATAR_POSITIVE_TTL_MS = 24 * 60 * 60 * 1000
+export const TWITCH_AVATAR_NEGATIVE_TTL_MS = 10 * 60 * 1000
+export const TWITCH_AVATAR_FETCH_TIMEOUT_MS = 3000
+
+function getCacheKey(authorId?: string | null): string | undefined {
+  if (!authorId) {
+    return undefined
+  }
+
+  return `twitch:${authorId}`
+}
+
+function normalizeAvatarUrl(value?: string | null): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function getEndpoint(userId: string): string {
+  return `${getBackendUrl()}/api/twitch/user?userId=${encodeURIComponent(userId)}`
+}
+
+export function createTwitchAvatarResolver({
+  fetchFn = fetch,
+  now = () => Date.now(),
+  timeoutMs = TWITCH_AVATAR_FETCH_TIMEOUT_MS,
+}: TwitchAvatarResolverDependencies = {}): TwitchAvatarResolver {
+  const cache = new Map<string, TwitchAvatarCacheEntry>()
+  const inFlight = new Map<string, Promise<string | undefined>>()
+
+  return async ({ authorId }: TwitchAvatarLookupInput) => {
+    const cacheKey = getCacheKey(authorId)
+    if (!cacheKey || !authorId) {
+      return undefined
+    }
+
+    const cached = cache.get(cacheKey)
+    const currentTime = now()
+    if (cached && cached.expiresAt > currentTime) {
+      return cached.avatarUrl
+    }
+
+    const pending = inFlight.get(cacheKey)
+    if (pending) {
+      return pending
+    }
+
+    const request = (async () => {
+      try {
+        const response = await fetchFn(getEndpoint(authorId), {
+          signal: AbortSignal.timeout(timeoutMs),
+        })
+
+        if (!response.ok) {
+          cache.set(cacheKey, { expiresAt: now() + TWITCH_AVATAR_NEGATIVE_TTL_MS })
+          return undefined
+        }
+
+        const body = (await response.json()) as {
+          user?: { profile_image_url?: string | null }
+        }
+        const avatarUrl = normalizeAvatarUrl(body.user?.profile_image_url)
+
+        cache.set(cacheKey, {
+          avatarUrl,
+          expiresAt:
+            now() + (avatarUrl ? TWITCH_AVATAR_POSITIVE_TTL_MS : TWITCH_AVATAR_NEGATIVE_TTL_MS),
+        })
+
+        return avatarUrl
+      } catch {
+        cache.set(cacheKey, { expiresAt: now() + TWITCH_AVATAR_NEGATIVE_TTL_MS })
+        return undefined
+      } finally {
+        inFlight.delete(cacheKey)
+      }
+    })()
+
+    inFlight.set(cacheKey, request)
+    return request
+  }
+}
+
+export const resolveTwitchAvatarUrl = createTwitchAvatarResolver()

--- a/packages/desktop/src/shared/rpc.ts
+++ b/packages/desktop/src/shared/rpc.ts
@@ -31,6 +31,8 @@ import type {
   SearchCategoriesResponse,
   SevenTVEmote,
   StreamStatusResponse,
+  UserCardMetadataRequest,
+  UserCardMetadataResponse,
   UpdateStreamRequest,
   UpdateStreamResponse,
 } from '@twirchat/shared/protocol'
@@ -129,6 +131,11 @@ type BunRequests = {
       cursor?: UserChatHistoryCursor
     }
     response: UserChatHistoryPage
+  }
+  /** Return backend-routed metadata for the user card */
+  getUserCardMetadata: {
+    params: UserCardMetadataRequest
+    response: UserCardMetadataResponse
   }
   /** Return current connection status for all platform adapters */
   getStatuses: {

--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -537,6 +537,7 @@ function onAppearanceChange(s: AppSettings) {
       v-model:open="isUserCardDialogOpen"
       :platform="selectedUserCardTarget.platform"
       :platform-user-id="selectedUserCardTarget.platformUserId"
+      :channel-id="selectedUserCardTarget.channelId"
       :display-name="selectedUserCardTarget.displayName"
       :username="selectedUserCardTarget.username"
       :avatar-url="selectedUserCardTarget.avatarUrl"

--- a/packages/desktop/src/views/main/components/ChatList.vue
+++ b/packages/desktop/src/views/main/components/ChatList.vue
@@ -75,8 +75,19 @@ function onReply(msg: NormalizedChatMessage) {
   replyTarget.value = msg
 }
 
+function getChannelSlugForPlatform(platform: Platform): string | undefined {
+  if (props.watchedChannel?.platform === platform) {
+    return props.watchedChannel.channelSlug
+  }
+
+  return props.statuses.get(platform)?.channelLogin
+}
+
 function onOpenUserCard(target: UserCardTarget) {
-  selectedUserCardTarget.value = target
+  selectedUserCardTarget.value = {
+    ...target,
+    channelSlug: target.channelSlug ?? getChannelSlugForPlatform(target.platform),
+  }
   isUserCardDialogOpen.value = true
 }
 
@@ -408,6 +419,7 @@ function onAppearanceChange(s: AppSettings) {
           <ChatMessage
             :key="item.id"
             :message="item"
+            :channel-slug="getChannelSlugForPlatform(item.platform)"
             :alias="getAliasForMessage(item)"
             :show-platform-color-stripe="settings?.showPlatformColorStripe"
             :show-platform-icon="settings?.showPlatformIcon"
@@ -538,6 +550,7 @@ function onAppearanceChange(s: AppSettings) {
       :platform="selectedUserCardTarget.platform"
       :platform-user-id="selectedUserCardTarget.platformUserId"
       :channel-id="selectedUserCardTarget.channelId"
+      :channel-slug="selectedUserCardTarget.channelSlug"
       :display-name="selectedUserCardTarget.displayName"
       :username="selectedUserCardTarget.username"
       :avatar-url="selectedUserCardTarget.avatarUrl"

--- a/packages/desktop/src/views/main/components/ChatMessage.vue
+++ b/packages/desktop/src/views/main/components/ChatMessage.vue
@@ -252,6 +252,7 @@ function scopeBadgeSvg(svgString: string, badgeId: string): string {
         v-else
         :platform="message.platform"
         :platform-user-id="message.author.id"
+        :channel-id="message.channelId"
         :display-name="message.author.displayName"
         :username="message.author.username"
         :avatar-url="message.author.avatarUrl"
@@ -438,6 +439,7 @@ function scopeBadgeSvg(svgString: string, badgeId: string): string {
           v-else
           :platform="message.platform"
           :platform-user-id="message.author.id"
+          :channel-id="message.channelId"
           :display-name="message.author.displayName"
           :username="message.author.username"
           :avatar-url="message.author.avatarUrl"

--- a/packages/desktop/src/views/main/components/ChatMessage.vue
+++ b/packages/desktop/src/views/main/components/ChatMessage.vue
@@ -12,6 +12,7 @@ import { useMessageParsing } from '../composables/useMessageParsing'
 
 const props = defineProps<{
   message: NormalizedChatMessage
+  channelSlug?: string
   showPlatformColorStripe?: boolean
   showPlatformIcon?: boolean
   showTimestamp?: boolean
@@ -253,6 +254,7 @@ function scopeBadgeSvg(svgString: string, badgeId: string): string {
         :platform="message.platform"
         :platform-user-id="message.author.id"
         :channel-id="message.channelId"
+        :channel-slug="props.channelSlug"
         :display-name="message.author.displayName"
         :username="message.author.username"
         :avatar-url="message.author.avatarUrl"
@@ -440,6 +442,7 @@ function scopeBadgeSvg(svgString: string, badgeId: string): string {
           :platform="message.platform"
           :platform-user-id="message.author.id"
           :channel-id="message.channelId"
+          :channel-slug="props.channelSlug"
           :display-name="message.author.displayName"
           :username="message.author.username"
           :avatar-url="message.author.avatarUrl"

--- a/packages/desktop/src/views/main/components/UserCardDialog.vue
+++ b/packages/desktop/src/views/main/components/UserCardDialog.vue
@@ -15,6 +15,7 @@ interface Props {
   platform: Platform
   platformUserId: string
   channelId?: string
+  channelSlug?: string
   displayName: string
   username?: string
   avatarUrl?: string
@@ -29,12 +30,16 @@ const aliasValue = ref('')
 const aliasInput = ref<HTMLInputElement | null>(null)
 const platformRef = toRef(props, 'platform')
 const platformUserIdRef = toRef(props, 'platformUserId')
+const usernameRef = toRef(props, 'username')
 const channelIdRef = toRef(props, 'channelId')
+const channelSlugRef = toRef(props, 'channelSlug')
 
 const { metadata, loading, error, reload, supportedByCard } = useUserCardMetadata(
   platformRef,
   platformUserIdRef,
+  usernameRef,
   channelIdRef,
+  channelSlugRef,
   open,
 )
 
@@ -473,12 +478,14 @@ function initials(name: string): string {
 
 .user-card-metadata-list {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 10px;
   margin: 0;
 }
 
 .user-card-metadata-item {
-  padding: 12px 14px;
+  min-width: 0;
+  padding: 12px;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 10px;
   background: rgba(0, 0, 0, 0.16);
@@ -498,6 +505,7 @@ function initials(name: string): string {
   font-size: 13px;
   color: var(--c-text, #e2e2e8);
   line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .dialog-input {

--- a/packages/desktop/src/views/main/components/UserCardDialog.vue
+++ b/packages/desktop/src/views/main/components/UserCardDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { DialogContent, DialogOverlay, DialogPortal, DialogRoot } from 'reka-ui'
 import type { Platform } from '@twirchat/shared/types'
 
@@ -7,12 +7,14 @@ import KickIcon from '../../../assets/icons/platforms/kick.svg'
 import TwitchIcon from '../../../assets/icons/platforms/twitch.svg'
 import YoutubeIcon from '../../../assets/icons/platforms/youtube.svg'
 import { platformColor } from '../../shared/utils/platform'
+import { useUserCardMetadata } from '../composables/useUserCardMetadata'
 import { useAliasStore } from '../stores/useAliasStore'
 import UserChatHistoryPanel from './UserChatHistoryPanel.vue'
 
 interface Props {
   platform: Platform
   platformUserId: string
+  channelId?: string
   displayName: string
   username?: string
   avatarUrl?: string
@@ -25,6 +27,16 @@ const open = defineModel<boolean>('open', { required: true })
 const aliasStore = useAliasStore()
 const aliasValue = ref('')
 const aliasInput = ref<HTMLInputElement | null>(null)
+const platformRef = toRef(props, 'platform')
+const platformUserIdRef = toRef(props, 'platformUserId')
+const channelIdRef = toRef(props, 'channelId')
+
+const { metadata, loading, error, reload, supportedByCard } = useUserCardMetadata(
+  platformRef,
+  platformUserIdRef,
+  channelIdRef,
+  open,
+)
 
 watch(
   open,
@@ -43,6 +55,79 @@ const platformIcon = computed(() => {
 })
 
 const titleHandle = computed(() => props.username ?? props.platformUserId)
+
+function formatAbsoluteDate(value: string | null | undefined): string | null {
+  if (!value) return null
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toLocaleDateString()
+}
+
+const accountAgeText = computed(() => {
+  const field = metadata.value?.accountAge
+  if (!field) return null
+
+  if (field.status === 'available') {
+    return `Created ${formatAbsoluteDate(field.createdAt) ?? field.createdAt}`
+  }
+
+  return field.message ?? 'Unavailable'
+})
+
+const followAgeText = computed(() => {
+  const field = metadata.value?.followAge
+  if (!field) return null
+
+  if (field.status === 'available') {
+    return `Following since ${formatAbsoluteDate(field.followedAt) ?? field.followedAt}`
+  }
+
+  return field.message ?? 'Unavailable'
+})
+
+const subscriptionDurationText = computed(() => {
+  const field = metadata.value?.subscriptionDuration
+  if (!field) return null
+
+  if (field.status === 'available') {
+    if (field.currentlySubscribed === true) {
+      const parts = ['Currently subscribed']
+
+      if (field.tier) {
+        parts.push(`Tier ${field.tier}`)
+      }
+
+      if (field.isGift) {
+        parts.push(field.gifterDisplayName ? `Gifted by ${field.gifterDisplayName}` : 'Gifted sub')
+      }
+
+      if (field.message) {
+        parts.push(field.message)
+      }
+
+      return parts.join(' · ')
+    }
+
+    return field.message ?? 'Not currently subscribed'
+  }
+
+  return field.message ?? 'Unavailable'
+})
+
+const subAgeText = computed(() => {
+  const field = metadata.value?.subAge
+  if (!field) return null
+
+  if (field.status === 'available' && field.months !== null) {
+    return `${field.months} month${field.months === 1 ? '' : 's'}`
+  }
+
+  return field.message ?? 'Unavailable'
+})
 
 function focusInput() {
   aliasInput.value?.focus()
@@ -127,6 +212,51 @@ function initials(name: string): string {
               Remove alias
             </button>
           </div>
+        </div>
+
+        <div class="user-card-section">
+          <div class="user-card-metadata-header">
+            <div>
+              <h4 class="user-card-metadata-title">Account metadata</h4>
+              <p class="dialog-description">Fetched through the backend for this platform.</p>
+            </div>
+
+            <button
+              v-if="supportedByCard"
+              class="user-card-metadata-refresh"
+              :disabled="loading"
+              @click="void reload()"
+            >
+              Refresh
+            </button>
+          </div>
+
+          <div v-if="!supportedByCard" class="user-card-metadata-state">
+            Metadata is not supported for this platform yet.
+          </div>
+          <div v-else-if="loading" class="user-card-metadata-state">Loading metadata…</div>
+          <div v-else-if="error" class="user-card-metadata-state user-card-metadata-state-error">
+            <span>{{ error }}</span>
+            <button class="user-card-metadata-inline-btn" @click="void reload()">Retry</button>
+          </div>
+          <dl v-else-if="metadata" class="user-card-metadata-list">
+            <div class="user-card-metadata-item">
+              <dt>Account age</dt>
+              <dd>{{ accountAgeText }}</dd>
+            </div>
+            <div class="user-card-metadata-item">
+              <dt>Follow age</dt>
+              <dd>{{ followAgeText }}</dd>
+            </div>
+            <div class="user-card-metadata-item">
+              <dt>Subscription duration</dt>
+              <dd>{{ subscriptionDurationText }}</dd>
+            </div>
+            <div class="user-card-metadata-item">
+              <dt>Sub age</dt>
+              <dd>{{ subAgeText }}</dd>
+            </div>
+          </dl>
         </div>
 
         <UserChatHistoryPanel
@@ -278,6 +408,96 @@ function initials(name: string): string {
   gap: 10px;
   align-items: center;
   margin-top: 12px;
+}
+
+.user-card-metadata-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.user-card-metadata-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--c-text, #e2e2e8);
+}
+
+.user-card-metadata-refresh,
+.user-card-metadata-inline-btn {
+  border: none;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--c-text, #e2e2e8);
+  cursor: pointer;
+  font: inherit;
+}
+
+.user-card-metadata-refresh {
+  padding: 7px 10px;
+  font-size: 12px;
+}
+
+.user-card-metadata-inline-btn {
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.user-card-metadata-refresh:disabled,
+.user-card-metadata-inline-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.user-card-metadata-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 96px;
+  padding: 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--c-text-2, #8b8b99);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.16);
+}
+
+.user-card-metadata-state-error {
+  color: #fca5a5;
+  flex-direction: column;
+}
+
+.user-card-metadata-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.user-card-metadata-item {
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.16);
+}
+
+.user-card-metadata-item dt {
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-2, #8b8b99);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.user-card-metadata-item dd {
+  margin: 0;
+  font-size: 13px;
+  color: var(--c-text, #e2e2e8);
+  line-height: 1.45;
 }
 
 .dialog-input {

--- a/packages/desktop/src/views/main/components/UserContextMenu.vue
+++ b/packages/desktop/src/views/main/components/UserContextMenu.vue
@@ -8,6 +8,7 @@ interface Props {
   platform: Platform
   platformUserId: string
   channelId?: string
+  channelSlug?: string
   displayName: string
   username?: string
   avatarUrl?: string
@@ -38,6 +39,7 @@ function onContextMenu(event: MouseEvent): void {
     :platform="platform"
     :platform-user-id="platformUserId"
     :channel-id="channelId"
+    :channel-slug="channelSlug"
     :display-name="displayName"
     :username="username"
     :avatar-url="avatarUrl"

--- a/packages/desktop/src/views/main/components/UserContextMenu.vue
+++ b/packages/desktop/src/views/main/components/UserContextMenu.vue
@@ -7,6 +7,7 @@ import UserCardDialog from './UserCardDialog.vue'
 interface Props {
   platform: Platform
   platformUserId: string
+  channelId?: string
   displayName: string
   username?: string
   avatarUrl?: string
@@ -36,6 +37,7 @@ function onContextMenu(event: MouseEvent): void {
     v-model:open="dialogOpen"
     :platform="platform"
     :platform-user-id="platformUserId"
+    :channel-id="channelId"
     :display-name="displayName"
     :username="username"
     :avatar-url="avatarUrl"

--- a/packages/desktop/src/views/main/composables/useUserCardMetadata.ts
+++ b/packages/desktop/src/views/main/composables/useUserCardMetadata.ts
@@ -7,7 +7,9 @@ import { rpc } from '../main'
 export function useUserCardMetadata(
   platform: Ref<Platform>,
   platformUserId: Ref<string>,
+  username: Ref<string | undefined>,
   channelId: Ref<string | undefined>,
+  channelSlug: Ref<string | undefined>,
   isActive: Ref<boolean>,
 ): {
   metadata: Readonly<Ref<UserCardMetadataResponse | null>>
@@ -40,7 +42,9 @@ export function useUserCardMetadata(
       const response = await rpc.request.getUserCardMetadata({
         platform: platform.value as 'twitch' | 'kick',
         platformUserId: platformUserId.value,
+        username: username.value,
         channelId: channelId.value,
+        channelSlug: channelSlug.value,
       })
 
       if (generation !== requestGeneration.value) return
@@ -57,7 +61,7 @@ export function useUserCardMetadata(
   }
 
   watch(
-    [platform, platformUserId, channelId],
+    [platform, platformUserId, username, channelId, channelSlug],
     () => {
       requestGeneration.value += 1
       metadata.value = null

--- a/packages/desktop/src/views/main/composables/useUserCardMetadata.ts
+++ b/packages/desktop/src/views/main/composables/useUserCardMetadata.ts
@@ -1,0 +1,91 @@
+import { computed, readonly, ref, watch, type Ref } from 'vue'
+
+import type { UserCardMetadataResponse } from '@twirchat/shared/protocol'
+import type { Platform } from '@twirchat/shared/types'
+import { rpc } from '../main'
+
+export function useUserCardMetadata(
+  platform: Ref<Platform>,
+  platformUserId: Ref<string>,
+  channelId: Ref<string | undefined>,
+  isActive: Ref<boolean>,
+): {
+  metadata: Readonly<Ref<UserCardMetadataResponse | null>>
+  loading: Readonly<Ref<boolean>>
+  error: Readonly<Ref<string | null>>
+  supportedByCard: Readonly<Ref<boolean>>
+  reload: () => Promise<void>
+} {
+  const metadata = ref<UserCardMetadataResponse | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const requestGeneration = ref(0)
+
+  const supportedByCard = computed(() => platform.value === 'twitch' || platform.value === 'kick')
+
+  async function reload(): Promise<void> {
+    if (!supportedByCard.value || !isActive.value) {
+      metadata.value = null
+      error.value = null
+      loading.value = false
+      return
+    }
+
+    const generation = requestGeneration.value + 1
+    requestGeneration.value = generation
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await rpc.request.getUserCardMetadata({
+        platform: platform.value as 'twitch' | 'kick',
+        platformUserId: platformUserId.value,
+        channelId: channelId.value,
+      })
+
+      if (generation !== requestGeneration.value) return
+      metadata.value = response
+    } catch (loadError) {
+      if (generation !== requestGeneration.value) return
+      metadata.value = null
+      error.value = loadError instanceof Error ? loadError.message : String(loadError)
+    } finally {
+      if (generation === requestGeneration.value) {
+        loading.value = false
+      }
+    }
+  }
+
+  watch(
+    [platform, platformUserId, channelId],
+    () => {
+      requestGeneration.value += 1
+      metadata.value = null
+      error.value = null
+      loading.value = false
+
+      if (isActive.value && supportedByCard.value) {
+        void reload()
+      }
+    },
+    { flush: 'sync' },
+  )
+
+  watch(
+    isActive,
+    (active) => {
+      if (active && supportedByCard.value) {
+        void reload()
+      }
+    },
+    { immediate: true },
+  )
+
+  return {
+    metadata: readonly(metadata),
+    loading: readonly(loading),
+    error: readonly(error),
+    supportedByCard: readonly(supportedByCard),
+    reload,
+  }
+}

--- a/packages/desktop/src/views/main/utils/chatCommands.ts
+++ b/packages/desktop/src/views/main/utils/chatCommands.ts
@@ -3,6 +3,7 @@ import type { NormalizedChatMessage, Platform } from '@twirchat/shared/types'
 export interface UserCardTarget {
   platform: Platform
   platformUserId: string
+  channelId?: string
   displayName: string
   username?: string
   avatarUrl?: string
@@ -66,6 +67,7 @@ export function resolveUserCardCommand(
     deduped.set(key, {
       platform: msg.platform,
       platformUserId: msg.author.id,
+      channelId: msg.channelId,
       displayName: msg.author.displayName,
       username: msg.author.username,
       avatarUrl: msg.author.avatarUrl,

--- a/packages/desktop/src/views/main/utils/chatCommands.ts
+++ b/packages/desktop/src/views/main/utils/chatCommands.ts
@@ -4,6 +4,7 @@ export interface UserCardTarget {
   platform: Platform
   platformUserId: string
   channelId?: string
+  channelSlug?: string
   displayName: string
   username?: string
   avatarUrl?: string

--- a/packages/desktop/tests/chatCommands.test.ts
+++ b/packages/desktop/tests/chatCommands.test.ts
@@ -41,6 +41,7 @@ describe('resolveUserCardCommand', () => {
       target: {
         platform: 'twitch',
         platformUserId: 'user-1',
+        channelId: 'channel-1',
         displayName: 'Satont',
         username: 'satont',
         avatarUrl: undefined,
@@ -59,6 +60,7 @@ describe('resolveUserCardCommand', () => {
       target: {
         platform: 'twitch',
         platformUserId: 'user-1',
+        channelId: 'channel-1',
         displayName: 'Satont',
         username: 'satont',
         avatarUrl: undefined,

--- a/packages/desktop/tests/twitch-avatar-cache.test.ts
+++ b/packages/desktop/tests/twitch-avatar-cache.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+import { createTwitchAvatarResolver } from '../src/platforms/twitch/avatar-cache'
+
+describe('createTwitchAvatarResolver', () => {
+  test('fetches avatar from backend twitch user endpoint and caches it', async () => {
+    const calls: string[] = []
+    const resolver = createTwitchAvatarResolver({
+      fetchFn: mock(async (input: string | URL | Request) => {
+        const url = String(input)
+        calls.push(url)
+
+        return Response.json({
+          user: {
+            profile_image_url: 'https://example.com/avatar.png',
+          },
+        })
+      }) as unknown as typeof fetch,
+    })
+
+    const first = await resolver({ authorId: '12345' })
+    const second = await resolver({ authorId: '12345' })
+
+    expect(first).toBe('https://example.com/avatar.png')
+    expect(second).toBe('https://example.com/avatar.png')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('/api/twitch/user?userId=12345')
+  })
+})

--- a/packages/shared/protocol.ts
+++ b/packages/shared/protocol.ts
@@ -333,12 +333,22 @@ export type UserCardFieldStatus = 'available' | 'unavailable' | 'unsupported' | 
 export interface UserCardMetadataRequest {
   platform: UserCardMetadataPlatform
   platformUserId: string
+  username?: string
   /**
    * Chat channel context from the selected message.
    * Twitch messages currently carry the channel login here.
    * Kick messages currently carry the broadcaster user id here.
    */
   channelId?: string
+  channelSlug?: string
+}
+
+export interface UserCardMetadataBackendRequest extends UserCardMetadataRequest {
+  twitchAuth?: {
+    accessToken: string
+    platformUserId: string
+    scopes: string[]
+  }
 }
 
 export interface UserCardAccountAgeField {

--- a/packages/shared/protocol.ts
+++ b/packages/shared/protocol.ts
@@ -326,6 +326,58 @@ export interface SearchCategoriesResponse {
   categories: CategorySearchResult[]
 }
 
+export type UserCardMetadataPlatform = Extract<Platform, 'twitch' | 'kick'>
+
+export type UserCardFieldStatus = 'available' | 'unavailable' | 'unsupported' | 'missing_permission'
+
+export interface UserCardMetadataRequest {
+  platform: UserCardMetadataPlatform
+  platformUserId: string
+  /**
+   * Chat channel context from the selected message.
+   * Twitch messages currently carry the channel login here.
+   * Kick messages currently carry the broadcaster user id here.
+   */
+  channelId?: string
+}
+
+export interface UserCardAccountAgeField {
+  status: UserCardFieldStatus
+  createdAt: string | null
+  message?: string
+}
+
+export interface UserCardFollowAgeField {
+  status: UserCardFieldStatus
+  followedAt: string | null
+  message?: string
+}
+
+export interface UserCardSubscriptionDurationField {
+  status: UserCardFieldStatus
+  currentlySubscribed: boolean | null
+  tier?: string
+  isGift?: boolean
+  gifterDisplayName?: string
+  message?: string
+}
+
+export interface UserCardSubAgeField {
+  status: UserCardFieldStatus
+  months: number | null
+  message?: string
+}
+
+export interface UserCardMetadataResponse {
+  platform: UserCardMetadataPlatform
+  platformUserId: string
+  fetchedAt: number
+  accountAge: UserCardAccountAgeField
+  followAge: UserCardFollowAgeField
+  subscriptionDuration: UserCardSubscriptionDurationField
+  subAge: UserCardSubAgeField
+}
+
 // ============================================================
 
 /** GET /api/accounts — список аккаунтов */


### PR DESCRIPTION
resolves #58

## Summary
- add backend-routed user card metadata for Twitch and Kick, including account age, follow age, subscription status, and explicit unsupported states for unavailable platform data
- thread message channel context through desktop user card entry points so Twitch follow/subscription lookups can resolve against the selected channel
- render the new metadata block in the desktop user card and cover the backend helper plus `/user` command plumbing with targeted tests

## Validation
- bun run --cwd packages/backend typecheck
- bun run --cwd packages/desktop typecheck
- bun test packages/backend/tests/user-card-metadata.test.ts
- bun test packages/desktop/tests/chatCommands.test.ts
- manual metadata helper execution for Twitch response shape

## Notes
- Twitch follow age and current subscription state are permission-gated and only shown when broadcaster/mod scopes allow them
- Kick currently returns explicit unsupported states for follow age, account age, and on-demand subscription tenure data
- workspace lint still reports pre-existing warnings outside this change set